### PR TITLE
feat: auto assign & no-auto-merge label control 기능 추가

### DIFF
--- a/.github/workflows/check-label.yml
+++ b/.github/workflows/check-label.yml
@@ -1,0 +1,22 @@
+name: Check Label
+on:
+  pull_request:
+    types: [ labeled, unlabeled ]
+
+jobs:
+   check-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: auto merge 끄기
+        if: "contains( github.event.pull_request.labels.*.name, 'no-auto-merge')"
+        run: gh pr merge --disable-auto "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.BOT_TOKEN}}
+
+      - name: auto merge 다시 켜기
+        if: "!contains( github.event.pull_request.labels.*.name, 'no-auto-merge')"
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.BOT_TOKEN}}

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -6,9 +6,14 @@ permissions:
   pull-requests: write
 
 jobs:
-  dependabot:
+  assign-author:
     runs-on: ubuntu-latest
     steps:
+      - uses: toshimaru/auto-author-assign@v1.1.0
+        with:
+          repo-token: "${{ secrets.BOT_TOKEN }}"
+
+  dependabot:
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --squash "$PR_URL"
         env:


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

1. assignee를 자동으로 추가합니다.
2. `no-auto-merge` 라벨을 붙이면, 오토 머지 기능을 해제합니다. 라벨을 제거하면 다시 오토 머지 기능을 활성화합니다.

## 💁 무엇이 어떻게 바뀌나요?
- 디자인 레퍼런스: 
- 관련 슬랙 링크: 

## 💬 리뷰어분들께 
<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!-- 
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->