### PR TITLE
feat(@depromeet/toks-components): Text 컴포넌트 tag 결정할수 있도록 수정

### DIFF
--- a/shared/toks-components/src/components/Text/index.tsx
+++ b/shared/toks-components/src/components/Text/index.tsx
@@ -7,7 +7,7 @@ import { Typography, typography as typographyObject } from './token';
 type FontWeight = 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 'normal' | 'bold' | 'bolder' | 'lighter';
 
 interface TextProps extends HTMLAttributes<HTMLSpanElement> {
-  // as?: 'span' | 'strong' | 'p' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'; // TODO: as 통해서 시멘틱 태그 사용 가능하게
+  as?: 'span' | 'strong' | 'p' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
   size?: number;
   weight?: FontWeight;
   color?: string; // TODO: color token type 추가
@@ -21,11 +21,13 @@ export function Text({
   weight = 'normal',
   color = theme.colors.white,
   children,
-  variant = 'body02',
+  variant,
+  as = 'span',
+
   ...rest
 }: TextProps) {
   return (
-    <StyledText size={size} weight={weight} color={color} variant={variant} {...rest}>
+    <StyledText size={size} weight={weight} color={color} variant={variant} as={as} {...rest}>
       {children}
     </StyledText>
   );
@@ -40,5 +42,5 @@ const StyledText = styled('span')<StyleProps>`
   letter-spacing: -0.6px;
   line-height: 100%;
 
-  ${({ variant }) => typographyObject[variant ?? 'body02']}
+  ${({ variant }) => (variant == null ? '' : typographyObject[variant])}
 `;


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->
1. tag 결정할 수 있도록
2. size, weight로 폰트 조정할 수 있도록 수정 (현재는 무조건 typographyObject[variant] 만 먹게 되어있음 )

## 💁 무엇이 어떻게 바뀌나요?
- 디자인 레퍼런스: 
- 관련 슬랙 링크: 

## 💬 리뷰어분들께 
<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!-- 
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->