### PR TITLE
feat(@shared/toks-components): Input 컴포넌트 임시 개발

### DIFF
--- a/services/quiz/src/pages/StudyDetailPage/index.tsx
+++ b/services/quiz/src/pages/StudyDetailPage/index.tsx
@@ -1,4 +1,4 @@
-import { BackButton, ToksHeader } from '@depromeet/toks-components';
+import { BackButton, Input, ToksHeader } from '@depromeet/toks-components';
 
 import { QuizList } from 'components/StudyDetailPage/QuizList';
 import { Ranking } from 'components/StudyDetailPage/Ranking';
@@ -21,6 +21,7 @@ export default function StudyDetailPage() {
           <Ranking />
         </Wrapper>
       </Section>
+      <Input />
     </Page>
   );
 }

--- a/services/quiz/src/pages/StudyDetailPage/index.tsx
+++ b/services/quiz/src/pages/StudyDetailPage/index.tsx
@@ -21,7 +21,6 @@ export default function StudyDetailPage() {
           <Ranking />
         </Wrapper>
       </Section>
-      <Input />
     </Page>
   );
 }

--- a/services/quiz/src/pages/StudyDetailPage/index.tsx
+++ b/services/quiz/src/pages/StudyDetailPage/index.tsx
@@ -1,4 +1,4 @@
-import { BackButton, Input, ToksHeader } from '@depromeet/toks-components';
+import { BackButton, ToksHeader } from '@depromeet/toks-components';
 
 import { QuizList } from 'components/StudyDetailPage/QuizList';
 import { Ranking } from 'components/StudyDetailPage/Ranking';

--- a/shared/toks-components/src/components/Input/index.tsx
+++ b/shared/toks-components/src/components/Input/index.tsx
@@ -1,21 +1,22 @@
 import { theme } from '@depromeet/theme';
 import { css } from '@emotion/react';
+import styled from '@emotion/styled';
 import { InputText } from 'primereact/inputtext';
 import { ComponentProps } from 'react';
-import styled from '@emotion/styled';
+
 import { Text } from '../Text';
 
 type InputTextProps = ComponentProps<typeof InputText>;
 
 interface Props extends Omit<InputTextProps, 'type'> {
-  type?: 'normal' | 'errored';
+  // type?: 'normal' | 'errored';
   width?: number;
   height?: number;
   label?: string;
   errorMessage?: string;
 }
 
-export function Input({ type = 'normal', label = 'user', errorMessage = 'error', width, height, ...props }: Props) {
+export function Input({ label = 'user', errorMessage = 'error', width, height, ...props }: Props) {
   return (
     <InputWrapper>
       <Text size={14} weight={400} className="label">

--- a/shared/toks-components/src/components/Input/index.tsx
+++ b/shared/toks-components/src/components/Input/index.tsx
@@ -1,12 +1,8 @@
 import { theme } from '@depromeet/theme';
 import { css } from '@emotion/react';
-
 import { InputText } from 'primereact/inputtext';
-
 import { ComponentProps } from 'react';
-
 import styled from '@emotion/styled';
-
 import { Text } from '../Text';
 
 type InputTextProps = ComponentProps<typeof InputText>;

--- a/shared/toks-components/src/components/Input/index.tsx
+++ b/shared/toks-components/src/components/Input/index.tsx
@@ -3,6 +3,7 @@ import { ComponentProps } from 'react';
 import styled from '@emotion/styled';
 import { theme } from '@depromeet/theme';
 import { css } from '@emotion/react';
+import { Text } from '../Text';
 
 type InputTextProps = ComponentProps<typeof InputText>;
 
@@ -10,19 +11,34 @@ interface Props extends Omit<InputTextProps, 'type'> {
   type?: 'normal' | 'errored';
   width?: number;
   height?: number;
+  label?: string;
+  errorMessage?: string;
 }
 
-export function Input({ type = 'normal', width, height, ...props }: Props) {
-  return <StyledInput width={width} height={height} {...props} placeholder="안녕하세요" />;
+export function Input({ type = 'normal', label = 'user', errorMessage = 'error', width, height, ...props }: Props) {
+  return (
+    <InputWrapper>
+      <Text size={14} weight={400} className="label">
+        {label}
+      </Text>
+      <StyledInput width={width} height={height} {...props} />
+      <Text size={14} weight={400}>
+        {errorMessage}
+      </Text>
+    </InputWrapper>
+  );
 }
 
-const StyledInput = styled(InputText)<InputTextProps>`
+const InputWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+const StyledInput = styled(InputText)<Props>`
   border-radius: 8px;
-  padding: 14px 16px;
   ${props => {
     const { width, height } = props;
     return css`
-      width: ${width ? `${width}px` : '100vw'};
+      width: ${width ? `${width}px` : '280px'};
       height: ${height ? `${height}px` : '48px'};
     `;
   }}
@@ -58,5 +74,9 @@ const StyledInput = styled(InputText)<InputTextProps>`
   &:invalid {
     border: #eb4852 1px solid !important;
     color: ${theme.colors.white};
+    outline: none !important;
+  }
+  .p-error-block {
+    color: #eb4852;
   }
 `;

--- a/shared/toks-components/src/components/Input/index.tsx
+++ b/shared/toks-components/src/components/Input/index.tsx
@@ -1,8 +1,12 @@
-import { InputText } from 'primereact/inputtext';
-import { ComponentProps } from 'react';
-import styled from '@emotion/styled';
 import { theme } from '@depromeet/theme';
 import { css } from '@emotion/react';
+
+import { InputText } from 'primereact/inputtext';
+
+import { ComponentProps } from 'react';
+
+import styled from '@emotion/styled';
+
 import { Text } from '../Text';
 
 type InputTextProps = ComponentProps<typeof InputText>;

--- a/shared/toks-components/src/components/Input/index.tsx
+++ b/shared/toks-components/src/components/Input/index.tsx
@@ -1,0 +1,62 @@
+import { InputText } from 'primereact/inputtext';
+import { ComponentProps } from 'react';
+import styled from '@emotion/styled';
+import { theme } from '@depromeet/theme';
+import { css } from '@emotion/react';
+
+type InputTextProps = ComponentProps<typeof InputText>;
+
+interface Props extends Omit<InputTextProps, 'type'> {
+  type?: 'normal' | 'errored';
+  width?: number;
+  height?: number;
+}
+
+export function Input({ type = 'normal', width, height, ...props }: Props) {
+  return <StyledInput width={width} height={height} {...props} placeholder="안녕하세요" />;
+}
+
+const StyledInput = styled(InputText)<InputTextProps>`
+  border-radius: 8px;
+  padding: 14px 16px;
+  ${props => {
+    const { width, height } = props;
+    return css`
+      width: ${width ? `${width}px` : '100vw'};
+      height: ${height ? `${height}px` : '48px'};
+    `;
+  }}
+  border: none !important;
+  background: ${theme.colors.gray100} !important;
+  ::placeholder {
+    color: ${theme.colors.gray070};
+  }
+  &:hover {
+    background: ${theme.colors.gray100} !important;
+    border: ${theme.colors.gray040} 1px solid !important;
+  }
+
+  &:focus {
+    border: #ff862f 2px solid !important;
+    background: ${theme.colors.gray100} !important;
+    outline: none !important;
+    box-shadow: none !important;
+    color: ${theme.colors.white};
+  }
+  &:disabled {
+    border: none !important;
+    background: ${theme.colors.gray110} !important;
+    ::placeholder {
+      color: ${theme.colors.gray080};
+    }
+  }
+  &:active {
+    color: ${theme.colors.white};
+    background: ${theme.colors.gray110} !important;
+    border: none !important;
+  }
+  &:invalid {
+    border: #eb4852 1px solid !important;
+    color: ${theme.colors.white};
+  }
+`;

--- a/shared/toks-components/src/components/index.ts
+++ b/shared/toks-components/src/components/index.ts
@@ -49,7 +49,7 @@ export * from 'primereact/inplace';
 export * from 'primereact/inputmask';
 export * from 'primereact/inputnumber';
 export * from 'primereact/inputswitch';
-export * from 'primereact/inputtext';
+export * from './Input';
 export * from 'primereact/inputtextarea';
 
 export * from 'primereact/keyfilter';


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->
- shared/toks-components에 Input 컴포넌트를 만들었습니다. 
- 컬러들은 반영했는데 label이나 error message를 작업하는 과정에서 prime react를 사용하지 않고 직접 커스텀을 하는 것이 맞는지 의문이 들어 풀리퀘 날립니다. 


- inactive
![image](https://user-images.githubusercontent.com/89721027/203649103-aeb5e218-5836-4626-8c32-906f01490319.png)

- hover
![image](https://user-images.githubusercontent.com/89721027/203649082-7667372b-50ab-4aaa-8970-787603dd0870.png)

- focused
![image](https://user-images.githubusercontent.com/89721027/203649063-dae8f933-bc9d-44d5-9beb-92d0db9eb491.png)

- invalid
![image](https://user-images.githubusercontent.com/89721027/203649046-1111124b-25a7-48af-a4eb-6651e1690b16.png)


## 💁 무엇이 어떻게 바뀌나요?


## 💬 리뷰어분들께 
<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->
- 커스텀이 생각보다 어렵네요 조언 주시면 감사하겠습니다. 
<!-- 
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->