### PR TITLE
feat(@depromeet/toks-components): Tooltip 컴포넌트 구현

### DIFF
--- a/shared/toks-components/src/components/Tooltip/index.tsx
+++ b/shared/toks-components/src/components/Tooltip/index.tsx
@@ -1,106 +1,72 @@
+import { theme } from '@depromeet/theme';
 import styled from '@emotion/styled';
 import { Tooltip as BaseTooltip } from 'primereact/tooltip';
 import { ComponentProps } from 'react';
 
-// type ButtonType = 'primary' | 'general' | 'ghost';
+type PositionType = 'top' | 'bottom' | 'right' | 'left';
 
-// type ButtonSize = 'medium' | 'large';
-
-// type BaseButtonProps = ComponentProps<typeof BaseButton>;
-
-// type ButtonStatus = 'normal' | 'hover' | 'disabled';
-
-// interface Props extends Omit<BaseButtonProps, 'type'> {
-//   type?: ButtonType;
-//   htmlType?: BaseButtonProps['type'];
-//   size?: ButtonSize;
-// }
-
-// type ButtonColorMap = {
-//   [key in ButtonStatus]: {
-//     [key in ButtonType]: string;
-//   };
-// };
-
-// const BUTTON_COLOR: ButtonColorMap = {
-//   normal: {
-//     primary: '#FF862F',
-//     ghost: 'transparent',
-//     general: '#FFFFFF',
-//   },
-//   hover: {
-//     primary: '#E96C12',
-//     ghost: '#A5A5A5',
-//     general: '#DFDFDF',
-//   },
-//   disabled: {
-//     primary: 'rgba(255, 134, 47, 0.4)',
-//     ghost: 'rgba(165, 165, 165, 0.4)',
-//     general: 'rgba(223, 223, 223, 0.4)',
-//   },
-// };
-
-// const BUTTOON_TEXT_COLOR: { [key in ButtonType]: string } = {
-//   primary: '#fff',
-//   general: '#000',
-//   ghost: '#fff',
-// };
-
-// const BUTTON_HEIGHT: { [key in ButtonSize]: string } = {
-//   large: '64px',
-//   medium: '46px',
-// };
-
-/*
-  -툴팁-
-  내용,
-  방향,
-  배경색,
-  래디우스,
-  패딩,
-  글자색,
-  폰트굵기
-*/
-
-interface TooltipProps {
-  description: string,
-  position: string,
-  backgroundColor: string,
-  borderRadius: string,
-  padding: string,
-  fontSize: string,
-  fontColor: string,
-  fontWeight: number
+interface TooltipProps extends Omit<ComponentProps<typeof BaseTooltip>, 'target' | 'content' | 'position'> {
+  target: string;
+  content: string;
+  position: PositionType;
 }
 
-export function Tooltip({ 
-  description,
-  position = "top",
-  backgroundColor = `${theme.colors.white}`,
-  borderRadius
-}: TooltipProps) {
-  return (
-    <StyledTooltip
+const isBottom = (position: PositionType) => position === 'bottom';
+
+/*
+TODO:
+- 툴팁 화살표 길이 늘어나게 구현해야함
+- 툴팁 방향에 따라 스타일 적용이 다른 부분에 대해서 중복성을 줄여야 함 
+*/
+export function Tooltip({ target, content, position }: TooltipProps) {
+  return isBottom(position) ? (
+    <StyledBottomTooltip
       // TODO: inline style로 적용한 부분 제외하기
-      style={{
-        background: BUTTON_COLOR[disabled ? 'disabled' : 'normal'][type],
-        borderRadius: '32px',
-        width: '224px',
-        height: BUTTON_HEIGHT[size],
-        border: type !== 'ghost' ? 'none' : '1px solid #A5A5A5',
-        color: BUTTOON_TEXT_COLOR[type],
-        fontWeight: '700',
-        fontSize: '16px',
-      }}
-      buttontype={type}
-      type={htmlType}
-      disabled={disabled}
-      loadingIcon={<ProgressSpinner strokeWidth="6px" style={{ width: '26px', height: '26px', margin: 0 }} />}
-      {...rest}
+      target={target}
+      content={content}
+      position={position}
     />
+  ) : (
+    <StyledRightTooltip target={target} content={content} position={position} />
   );
 }
 
-const StyledTooltip = styled(Tooltip)`
-  
+const StyledBottomTooltip = styled(BaseTooltip)<{ position: PositionType }>`
+  text-align: center;
+  margin-top: 4px;
+  color: ${theme.colors.gray120} !important;
+
+  .p-tooltip {
+  }
+  .p-tooltip-text {
+    font-size: 14px;
+    color: ${theme.colors.gray120} !important;
+    background: ${theme.colors.white} !important;
+    padding: 4px 16px !important;
+    border-radius: 8px !important;
+  }
+
+  .p-tooltip-arrow {
+    border-bottom-color: ${theme.colors.white} !important;
+  }
+`;
+
+const StyledRightTooltip = styled(BaseTooltip)<{ position: PositionType }>`
+  text-align: center;
+  margin-left: 4px;
+  color: ${theme.colors.gray120} !important;
+
+  .p-tooltip {
+  }
+  .p-tooltip-text {
+    font-size: 14px;
+    color: ${theme.colors.gray120} !important;
+    background: ${theme.colors.white} !important;
+    padding: 4px 16px !important;
+    border-radius: 8px !important;
+  }
+
+  .p-tooltip-arrow {
+    border-right-color: ${theme.colors.white} !important;
+  }
 `;

--- a/shared/toks-components/src/components/Tooltip/index.tsx
+++ b/shared/toks-components/src/components/Tooltip/index.tsx
@@ -1,0 +1,106 @@
+import styled from '@emotion/styled';
+import { Tooltip as BaseTooltip } from 'primereact/tooltip';
+import { ComponentProps } from 'react';
+
+// type ButtonType = 'primary' | 'general' | 'ghost';
+
+// type ButtonSize = 'medium' | 'large';
+
+// type BaseButtonProps = ComponentProps<typeof BaseButton>;
+
+// type ButtonStatus = 'normal' | 'hover' | 'disabled';
+
+// interface Props extends Omit<BaseButtonProps, 'type'> {
+//   type?: ButtonType;
+//   htmlType?: BaseButtonProps['type'];
+//   size?: ButtonSize;
+// }
+
+// type ButtonColorMap = {
+//   [key in ButtonStatus]: {
+//     [key in ButtonType]: string;
+//   };
+// };
+
+// const BUTTON_COLOR: ButtonColorMap = {
+//   normal: {
+//     primary: '#FF862F',
+//     ghost: 'transparent',
+//     general: '#FFFFFF',
+//   },
+//   hover: {
+//     primary: '#E96C12',
+//     ghost: '#A5A5A5',
+//     general: '#DFDFDF',
+//   },
+//   disabled: {
+//     primary: 'rgba(255, 134, 47, 0.4)',
+//     ghost: 'rgba(165, 165, 165, 0.4)',
+//     general: 'rgba(223, 223, 223, 0.4)',
+//   },
+// };
+
+// const BUTTOON_TEXT_COLOR: { [key in ButtonType]: string } = {
+//   primary: '#fff',
+//   general: '#000',
+//   ghost: '#fff',
+// };
+
+// const BUTTON_HEIGHT: { [key in ButtonSize]: string } = {
+//   large: '64px',
+//   medium: '46px',
+// };
+
+/*
+  -툴팁-
+  내용,
+  방향,
+  배경색,
+  래디우스,
+  패딩,
+  글자색,
+  폰트굵기
+*/
+
+interface TooltipProps {
+  description: string,
+  position: string,
+  backgroundColor: string,
+  borderRadius: string,
+  padding: string,
+  fontSize: string,
+  fontColor: string,
+  fontWeight: number
+}
+
+export function Tooltip({ 
+  description,
+  position = "top",
+  backgroundColor = `${theme.colors.white}`,
+  borderRadius
+}: TooltipProps) {
+  return (
+    <StyledTooltip
+      // TODO: inline style로 적용한 부분 제외하기
+      style={{
+        background: BUTTON_COLOR[disabled ? 'disabled' : 'normal'][type],
+        borderRadius: '32px',
+        width: '224px',
+        height: BUTTON_HEIGHT[size],
+        border: type !== 'ghost' ? 'none' : '1px solid #A5A5A5',
+        color: BUTTOON_TEXT_COLOR[type],
+        fontWeight: '700',
+        fontSize: '16px',
+      }}
+      buttontype={type}
+      type={htmlType}
+      disabled={disabled}
+      loadingIcon={<ProgressSpinner strokeWidth="6px" style={{ width: '26px', height: '26px', margin: 0 }} />}
+      {...rest}
+    />
+  );
+}
+
+const StyledTooltip = styled(Tooltip)`
+  
+`;

--- a/shared/toks-components/src/components/index.ts
+++ b/shared/toks-components/src/components/index.ts
@@ -107,7 +107,7 @@ export * from 'primereact/timeline';
 export * from 'primereact/toast';
 export * from 'primereact/togglebutton';
 export * from 'primereact/toolbar';
-export * from 'primereact/tooltip';
+export * from './Tooltip';
 export * from 'primereact/tree';
 export * from 'primereact/treeselect';
 export * from 'primereact/treetable';


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
- Tooltip 컴포넌트를 개발했습니다
- 색상은 흰 배경에 검정 글자가 디자인 시스템상 고정인거 같아서 커스텀 할 수 있게 별도 구현은 하지 않았습니다.
- 아래 구현 예시는 position이 right로 들어갔을 경우 입니다
- target을 통해서 툴팁을 띄울 요소를 선택자로 선택합니다.
- 화살표 길이는 어떻게 만져도 길이가 안늘어나고 이상하게 바뀌어서 일단은 미뤘습니다

<img width="320" alt="스크린샷 2022-11-25 오전 3 33 45" src="https://user-images.githubusercontent.com/47452547/203848485-a8793194-00b0-4343-be0c-d0f436f0c977.png">
## 💁 무엇이 어떻게 바뀌나요?
- 디자인 레퍼런스: 
- 관련 슬랙 링크: 


## 💬 리뷰어분들께 
툴팁의 방향에 따라서 바뀌어야 할 스타일 속성이 두개가 있습니다..
margin-{툴팁 반대 방향}
border-{툴팁 방향}-color
요 두 속성 값 인데요,
제 코드에서 StyledBottomTooltip, StyledRightTooltip 이렇게 굳이 두개로 나눠 놓은 이유가 방향에 따라서 스타일의 분기처리를
어떻게 해야할지 모르겠어서 이렇게 했습니다.. 허허

해당 부분 말고도 다른 부분 지적 환영입니다!

<!-- 
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore

-->