### PR TITLE
feat(@depromeet/http): 비회원 접근시 redirect 후에 delay추가

### DIFF
--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@depromeet/http",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "toks auth",
   "main": "src/index.ts",
   "module": "src/index.ts",

--- a/packages/http/src/http.ts
+++ b/packages/http/src/http.ts
@@ -105,10 +105,16 @@ instance.interceptors.response.use(
     if (isToksError(error) && (error.status === 401 || error.status === 403)) {
       //refresh 토큰 처리 로직 추가
       redirectToLoginPage();
+      // redirect가 완료되고, API가 종료될 수 있도록 delay를 추가합니다.
+      await delay(500);
     } else {
       throw error;
     }
   }
 );
+
+function delay(time: number) {
+  return new Promise(res => setTimeout(res, time));
+}
 
 export const http: ToksHttpClient = instance;


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->
브라우저 routing 동작의 비동기 문제로, 비회원을 로그인 페이지로 보낸 후 500ms만큼 delay를 주고 API 통신을 종료시킵니다.
(완전히 redirect이 끝난 후 API 종료시키기 위함)

## 💁 무엇이 어떻게 바뀌나요?
- 디자인 레퍼런스: 
- 관련 슬랙 링크: 

## 💬 리뷰어분들께 
<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!-- 
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->