### PR TITLE
fix(quiz): 랭킹에 긴 닉네임이 들어갈 경우 디자인 깨지는 현상 수정

### DIFF
--- a/services/quiz/src/pages/StudyDetailPage/components/RankingItem/index.tsx
+++ b/services/quiz/src/pages/StudyDetailPage/components/RankingItem/index.tsx
@@ -22,16 +22,26 @@ export function RankingItem({ rankItem }: RankingItemProps) {
       {isMedalItem(ranking) ? (
         <Icon height={32} iconName={medals[(ranking as number) - 1]} />
       ) : (
-        <Text variant="body02" color="gray040" css={{ padding: '0 5.5px' }}>
+        <Text variant="body02" color="gray040" css={{ width: '28px', textAlign: 'center' }}>
           {convertNoneRanking(ranking)}
         </Text>
       )}
       <UserAvatar image={user.profileImageUrl} size="large" css={{ marginLeft: '12px' }} />
-      <Text variant="body01" color="white" css={{ marginLeft: '12px', flex: 1 }}>
+      <Text
+        variant="body01"
+        color="white"
+        css={{
+          marginLeft: '12px',
+          flex: 1,
+          textOverflow: 'ellipsis',
+          overflow: 'hidden',
+          whiteSpace: 'nowrap',
+        }}
+      >
         {user.nickname}
       </Text>
-      <Text variant="body03" color="gray060" css={{ marginLeft: '12px', flex: 1 }}>
-        {score} Toks
+      <Text variant="body03" color="gray060" css={{ marginLeft: '12px' }}>
+        {score ?? 0} Toks
       </Text>
     </Item>
   );

--- a/services/quiz/src/pages/StudyDetailPage/components/RankingItem/style.ts
+++ b/services/quiz/src/pages/StudyDetailPage/components/RankingItem/style.ts
@@ -6,7 +6,6 @@ export const Item = styled.li`
   align-items: center;
   padding: 12px 42px;
   border-radius: 16px;
-
   :nth-of-type(n + 2) {
     margin-top: 12px;
   }

--- a/services/quiz/src/pages/StudyDetailPage/components/RankingList/index.tsx
+++ b/services/quiz/src/pages/StudyDetailPage/components/RankingList/index.tsx
@@ -17,7 +17,6 @@ function RankingList({ studyId }: RankingListProps) {
     return null;
   }
 
-  // TODO: 서버에서 랭킹 숫자 내려주냐 안내려주냐에 따라서 랭킹 추가하는 부분 구성해야 함
   return (
     <List>
       {rankingList.quizRanks.map(rankItem => (


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
- 숫자 랭킹을 그냥 너비 값으로 28px을 줌
- 닉네임 text에 ellipsis속성 추가
- 똑표에 flex:1 (왜 넣었었지,,)제거
<img width="324" alt="스크린샷 2023-01-05 오후 6 28 35" src="https://user-images.githubusercontent.com/47452547/210746847-4130fde4-edfc-47f0-8a73-62005a1ce8da.png">

## 💁 무엇이 어떻게 바뀌나요?
- 디자인 레퍼런스: 
- 관련 슬랙 링크: 

## 💬 리뷰어분들께 
<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!-- 
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->