### PR TITLE
feat(@depromeet/toks-components): Avatar에 기본 프로필 이미지가 들어가면 똑스 캐릭터가 나오게 구현

### DIFF
--- a/shared/toks-components/src/components/UserAvatar/index.tsx
+++ b/shared/toks-components/src/components/UserAvatar/index.tsx
@@ -29,7 +29,6 @@ const AVATAR_SIZE = {
   xlarge: '40px',
 };
 
-// TODO : 디폴트 이미지가 직접 넘어오는지 빈 값으로 넘어오는지에 따라 디폴트 프로필 이미지 출력을 구현해야함
 export function UserAvatar({
   image,
   label,
@@ -40,17 +39,17 @@ export function UserAvatar({
   tooltip = false,
 }: ImageAvatarProps & LabelAvatarProps) {
   const tooltipContent = userName ?? userNames.join(', ');
-  // const avatarClassName = image ? `avatar--user_${id}` : `avatar--group_${id}`;
-
+  const isBaseProfileImage =
+    image === 'http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg';
+  const baseProfileImage = 'https://toks-web-assets.s3.amazonaws.com/toks-emoji/ic-base-profile.png'; //"https://asset.tokstudy.com/toks-emoji/ic-base-profile.png";
   return (
     <>
       {tooltip && <Tooltip target={`.${className}`} content={tooltipContent} position="bottom" />}
       <StyledAvatar
-        image={image}
+        image={isBaseProfileImage ? baseProfileImage : image}
         label={label}
         size={size}
         shape="circle"
-        // TODO: inline style로 적용한 부분 제외하기...^^ (현구님 따라해서 일단 저도 이렇게 했슴다..)
         style={{
           width: AVATAR_SIZE[size ?? 'normal'],
           height: AVATAR_SIZE[size ?? 'normal'],


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
- 똑스 캐릭터가 나오게 하였습니다
- 기본이미지가 전부 [카톡 기본](http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg)이 이미지로 나오는거 같아서 요거로 분기처리 했지만 더 확인이 필요할것 같아욜
<img width="285" alt="스크린샷 2023-01-05 오후 7 15 03" src="https://user-images.githubusercontent.com/47452547/210756236-1fb44a4c-4d9f-49f9-a757-d52f2ff2d468.png">


## 💁 무엇이 어떻게 바뀌나요?
- 디자인 레퍼런스: 
- 관련 슬랙 링크: 

## 💬 리뷰어분들께 
<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!-- 
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->