### PR TITLE
feat(quiz): 퀴즈 생성 페이지 navbar 추가 및 뒤로가기 버튼 구현

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -6349,6 +6349,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@toss/react", "virtual:bf385740268fd646fb11939e2de4db770daf461f5380f1f23f2a193c453ad695c7fa46bf5f9fd706cfde63c5461e698d99c5ae46eacb0c996ed6a8d7fbf19e4d#npm:1.3.0"],\
             ["@toss/react-query", "virtual:bf385740268fd646fb11939e2de4db770daf461f5380f1f23f2a193c453ad695c7fa46bf5f9fd706cfde63c5461e698d99c5ae46eacb0c996ed6a8d7fbf19e4d#npm:1.1.0"],\
             ["@toss/use-overlay", "virtual:bf385740268fd646fb11939e2de4db770daf461f5380f1f23f2a193c453ad695c7fa46bf5f9fd706cfde63c5461e698d99c5ae46eacb0c996ed6a8d7fbf19e4d#npm:1.1.0"],\
+            ["@toss/use-query-param", "virtual:61593cfa096851f06fc809fe1cdab76affb0eb619e68badf225a4b0699422db3ab00d1df20a5e7cc2170090770167a6dff5fe75adc656c065a37aba556eb6aac#npm:1.1.3"],\
             ["@toss/utils", "npm:1.3.0"],\
             ["@types/node", "npm:18.11.9"],\
             ["@types/react", "npm:18.0.21"],\
@@ -7319,6 +7320,27 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@toss/use-query-param", "npm:1.1.3"]\
           ],\
           "linkType": "SOFT"\
+        }],\
+        ["virtual:61593cfa096851f06fc809fe1cdab76affb0eb619e68badf225a4b0699422db3ab00d1df20a5e7cc2170090770167a6dff5fe75adc656c065a37aba556eb6aac#npm:1.1.3", {\
+          "packageLocation": "./.yarn/__virtual__/@toss-use-query-param-virtual-860e9814d3/0/cache/@toss-use-query-param-npm-1.1.3-aee9f2ca8a-cebc7702ec.zip/node_modules/@toss/use-query-param/",\
+          "packageDependencies": [\
+            ["@toss/use-query-param", "virtual:61593cfa096851f06fc809fe1cdab76affb0eb619e68badf225a4b0699422db3ab00d1df20a5e7cc2170090770167a6dff5fe75adc656c065a37aba556eb6aac#npm:1.1.3"],\
+            ["@types/next", null],\
+            ["@types/react", "npm:18.0.21"],\
+            ["@types/react-dom", "npm:18.0.6"],\
+            ["next", "virtual:bf385740268fd646fb11939e2de4db770daf461f5380f1f23f2a193c453ad695c7fa46bf5f9fd706cfde63c5461e698d99c5ae46eacb0c996ed6a8d7fbf19e4d#npm:12.3.3"],\
+            ["react", "npm:18.2.0"],\
+            ["react-dom", "virtual:2b84034f2ee9abf066cdd40f914365517e5a655184b1d71768de9fc65205326162e6f6ab5016e627c91cf725255b89c00a8a14624ffa4091ec69e703b49aa9b2#npm:18.2.0"]\
+          ],\
+          "packagePeers": [\
+            "@types/next",\
+            "@types/react-dom",\
+            "@types/react",\
+            "next",\
+            "react-dom",\
+            "react"\
+          ],\
+          "linkType": "HARD"\
         }],\
         ["virtual:6245f8d7197665a29972bf49b07aa213ab4dbf01096fa34b00ebbb68ec2dfd5071b888c5fc986ed0c09805800e0c5af7a5d6e4f274939c9dc5420b693b2136de#npm:1.1.3", {\
           "packageLocation": "./.yarn/__virtual__/@toss-use-query-param-virtual-a02bfa94d4/0/cache/@toss-use-query-param-npm-1.1.3-aee9f2ca8a-cebc7702ec.zip/node_modules/@toss/use-query-param/",\

--- a/service/package.json
+++ b/service/package.json
@@ -32,6 +32,7 @@
     "@toss/react": "^1.3.0",
     "@toss/react-query": "^1.1.0",
     "@toss/use-overlay": "^1.1.0",
+    "@toss/use-query-param": "^1.1.3",
     "@toss/utils": "^1.3.0",
     "axios": "^0.27.2",
     "date-fns": "^2.29.3",

--- a/service/src/quiz/pages/QuizCheckingPage/components/AnswerCheckList/index.tsx
+++ b/service/src/quiz/pages/QuizCheckingPage/components/AnswerCheckList/index.tsx
@@ -16,6 +16,7 @@ export function AnswerCheckList({ durationTime }: { durationTime: number }) {
   const [isQuizClosed, setIsQuizClosed] = useState(false);
 
   const quizIdParams = usePathParam('quizIdParams', { suspense: true });
+
   const { time, stop: timerStop } = useTimer({
     time: durationTime,
   });

--- a/service/src/quiz/pages/QuizCheckingPage/index.tsx
+++ b/service/src/quiz/pages/QuizCheckingPage/index.tsx
@@ -36,7 +36,7 @@ export default function QuizCheckingPage() {
   const myAnswer = quizzes.quizReplyHistories.find(element => element.creator.nickname === user.nickname)?.answer;
   return (
     <>
-      <QuizNav mainTitle="똑표 확인하기" studyId={1} />
+      <QuizNav mainTitle="똑표 확인하기" studyId={quiz.studyId} />
       <Spacing size={25} />
       <Flex css={{ height: '100%' }}>
         <QuizQuestion myAnswer={myAnswer} />

--- a/service/src/quiz/pages/QuizCreatePage/index.tsx
+++ b/service/src/quiz/pages/QuizCreatePage/index.tsx
@@ -1,9 +1,10 @@
 import { FULL_HEIGHT } from '@depromeet/toks-components';
 import { useQueryParam } from '@depromeet/utils';
 import { Flex } from '@toss/emotion-utils';
-import { QuizNav } from 'quiz/common/components/QuizNav';
 import React from 'react';
 import { useForm } from 'react-hook-form';
+
+import { QuizNav } from 'quiz/common/components/QuizNav';
 
 import { QuizCreateEditor } from './components/QuizCreateEditor';
 import { QuizCreateInputList } from './components/QuizCreateInputList';

--- a/service/src/quiz/pages/QuizCreatePage/index.tsx
+++ b/service/src/quiz/pages/QuizCreatePage/index.tsx
@@ -1,18 +1,17 @@
-import { FULL_HEIGHT } from '@depromeet/toks-components';
+import { FULL_HEIGHT, getStudyDetail } from '@depromeet/toks-components';
 import { usePathParam } from '@depromeet/utils';
 import { Flex } from '@toss/emotion-utils';
 import React from 'react';
 import { useForm } from 'react-hook-form';
+import { useQuery } from 'react-query';
 
 import { QuizNav } from 'quiz/common/components/QuizNav';
+import { QUERY_KEYS } from 'quiz/constants/queryKeys';
 
 import { QuizCreateEditor } from './components/QuizCreateEditor';
 import { QuizCreateInputList } from './components/QuizCreateInputList';
 import { useQuizCreate } from './hooks/useQuizCreate';
 import { QuizCreateForm } from './types';
-import { useQuery } from 'react-query';
-import { QUERY_KEYS } from 'quiz/constants/queryKeys';
-import { getStudyDetail } from '@depromeet/toks-components';
 
 const QuizCreatePage = () => {
   const { register, setValue, control, getValues, setError } = useForm();

--- a/service/src/quiz/pages/QuizCreatePage/index.tsx
+++ b/service/src/quiz/pages/QuizCreatePage/index.tsx
@@ -19,7 +19,7 @@ const QuizCreatePage = () => {
   const { createQuiz } = useQuizCreate();
   const studyId = usePathParam('studyId', { suspense: true });
 
-  const { data: studyInfo } = useQuery([QUERY_KEYS.GET_STUDY_INFO], () => getStudyDetail(studyId));
+  const { data: studyInfo } = useQuery(QUERY_KEYS.GET_STUDY_INFO(studyId), () => getStudyDetail(studyId));
   if (!studyInfo) {
     return null;
   }

--- a/service/src/quiz/pages/QuizCreatePage/index.tsx
+++ b/service/src/quiz/pages/QuizCreatePage/index.tsx
@@ -1,5 +1,7 @@
 import { FULL_HEIGHT } from '@depromeet/toks-components';
+import { useQueryParam } from '@depromeet/utils';
 import { Flex } from '@toss/emotion-utils';
+import { QuizNav } from 'quiz/common/components/QuizNav';
 import React from 'react';
 import { useForm } from 'react-hook-form';
 
@@ -11,35 +13,42 @@ import { QuizCreateForm } from './types';
 const QuizCreatePage = () => {
   const { register, setValue, control, getValues, setError } = useForm();
   const { createQuiz } = useQuizCreate();
+  const studyId = useQueryParam('studyId', { suspense: true });
+  if (!studyId) {
+    return null;
+  }
 
   return (
-    <Flex.Center css={{ height: FULL_HEIGHT }}>
-      <form
-        onSubmit={(e: React.FormEvent) => {
-          e.preventDefault();
-          const values = getValues() as QuizCreateForm;
+    <>
+      <QuizNav mainTitle={''} studyId={studyId} />
+      <Flex.Center css={{ height: FULL_HEIGHT }}>
+        <form
+          onSubmit={(e: React.FormEvent) => {
+            e.preventDefault();
+            const values = getValues() as QuizCreateForm;
 
-          if (!values.answer) {
-            setError('answer', {
-              type: 'required',
-              message: '답을 입력해주세요',
-            });
-            return;
-          }
+            if (!values.answer) {
+              setError('answer', {
+                type: 'required',
+                message: '답을 입력해주세요',
+              });
+              return;
+            }
 
-          createQuiz(values);
-        }}
-      >
-        <Flex
-          css={{
-            gap: '48px',
+            createQuiz(values);
           }}
         >
-          <QuizCreateEditor register={register} setValue={setValue} />
-          <QuizCreateInputList register={register} setValue={setValue} control={control} />
-        </Flex>
-      </form>
-    </Flex.Center>
+          <Flex
+            css={{
+              gap: '48px',
+            }}
+          >
+            <QuizCreateEditor register={register} setValue={setValue} />
+            <QuizCreateInputList register={register} setValue={setValue} control={control} />
+          </Flex>
+        </form>
+      </Flex.Center>
+    </>
   );
 };
 

--- a/service/src/quiz/pages/QuizCreatePage/index.tsx
+++ b/service/src/quiz/pages/QuizCreatePage/index.tsx
@@ -1,5 +1,5 @@
 import { FULL_HEIGHT } from '@depromeet/toks-components';
-import { useQueryParam } from '@depromeet/utils';
+import { usePathParam } from '@depromeet/utils';
 import { Flex } from '@toss/emotion-utils';
 import React from 'react';
 import { useForm } from 'react-hook-form';
@@ -10,18 +10,27 @@ import { QuizCreateEditor } from './components/QuizCreateEditor';
 import { QuizCreateInputList } from './components/QuizCreateInputList';
 import { useQuizCreate } from './hooks/useQuizCreate';
 import { QuizCreateForm } from './types';
+import { useQuery } from 'react-query';
+import { QUERY_KEYS } from 'quiz/constants/queryKeys';
+import { getStudyDetail } from '@depromeet/toks-components';
 
 const QuizCreatePage = () => {
   const { register, setValue, control, getValues, setError } = useForm();
   const { createQuiz } = useQuizCreate();
-  const studyId = useQueryParam('studyId', { suspense: true });
-  if (!studyId) {
+  const studyId = usePathParam('studyId', { suspense: true });
+
+  const { data: studyInfo } = useQuery([QUERY_KEYS.GET_STUDY_INFO], () => getStudyDetail(studyId));
+  if (!studyInfo) {
     return null;
   }
 
   return (
     <>
-      <QuizNav mainTitle={''} studyId={studyId} />
+      <QuizNav
+        mainTitle={`${studyInfo.latestQuizRound + 1}회차 똑스 만들기`}
+        studyId={studyId}
+        subTitle={`${studyInfo.name}`}
+      />
       <Flex.Center css={{ height: FULL_HEIGHT }}>
         <form
           onSubmit={(e: React.FormEvent) => {

--- a/service/src/quiz/pages/QuizSolvingPage/components/QuizEditor/index.tsx
+++ b/service/src/quiz/pages/QuizSolvingPage/components/QuizEditor/index.tsx
@@ -38,6 +38,7 @@ export function QuizEditor() {
   const [answer, setAnswer] = useState('');
 
   const quizIdParams = usePathParam('quizIdParams', { suspense: true });
+
   const quizId = Number(quizIdParams);
 
   //button disable 제어

--- a/service/src/quiz/pages/QuizSolvingPage/index.tsx
+++ b/service/src/quiz/pages/QuizSolvingPage/index.tsx
@@ -5,12 +5,24 @@ import { QuizQuestion } from 'quiz/common/components/QuizQuestion';
 
 import { QuizEditor } from './components/QuizEditor';
 import { StudyPeerAnswer } from './components/StudyPeerAnswer';
+import { useQuery } from 'react-query';
+import { QUERY_KEYS } from 'quiz/constants/queryKeys';
+import { useQueryParam } from '@depromeet/utils';
+import { getQuizById } from 'quiz/common/components/QuizQuestion/remotes/quiz';
 
 export default function QuizSolvingPage() {
-  //TODO: studyId 받아오기
+  const quizIdParams = useQueryParam('quizIdParams', { suspense: true });
+
+  const { data: quiz } = useQuery(QUERY_KEYS.GET_QUIZ_BY_ID, () => getQuizById(quizIdParams), {
+    enabled: Boolean(quizIdParams),
+  });
+  if (!quiz) {
+    return null;
+  }
+
   return (
     <>
-      <QuizNav mainTitle="똑스 풀기" studyId={1} />
+      <QuizNav mainTitle="똑스 풀기" studyId={quiz?.studyId} />
       <Spacing size={25} />
       <Flex css={{ height: '100%' }}>
         <QuizQuestion />

--- a/service/src/quiz/pages/QuizSolvingPage/index.tsx
+++ b/service/src/quiz/pages/QuizSolvingPage/index.tsx
@@ -1,14 +1,14 @@
+import { useQueryParam } from '@depromeet/utils';
 import { Flex, Spacing } from '@toss/emotion-utils';
+import { useQuery } from 'react-query';
 
 import { QuizNav } from 'quiz/common/components/QuizNav';
 import { QuizQuestion } from 'quiz/common/components/QuizQuestion';
+import { getQuizById } from 'quiz/common/components/QuizQuestion/remotes/quiz';
+import { QUERY_KEYS } from 'quiz/constants/queryKeys';
 
 import { QuizEditor } from './components/QuizEditor';
 import { StudyPeerAnswer } from './components/StudyPeerAnswer';
-import { useQuery } from 'react-query';
-import { QUERY_KEYS } from 'quiz/constants/queryKeys';
-import { useQueryParam } from '@depromeet/utils';
-import { getQuizById } from 'quiz/common/components/QuizQuestion/remotes/quiz';
 
 export default function QuizSolvingPage() {
   const quizIdParams = useQueryParam('quizIdParams', { suspense: true });

--- a/service/src/quiz/pages/QuizSolvingPage/index.tsx
+++ b/service/src/quiz/pages/QuizSolvingPage/index.tsx
@@ -1,4 +1,4 @@
-import { useQueryParam } from '@depromeet/utils';
+import { usePathParam } from '@depromeet/utils';
 import { Flex, Spacing } from '@toss/emotion-utils';
 import { useQuery } from 'react-query';
 
@@ -11,9 +11,9 @@ import { QuizEditor } from './components/QuizEditor';
 import { StudyPeerAnswer } from './components/StudyPeerAnswer';
 
 export default function QuizSolvingPage() {
-  const quizIdParams = useQueryParam('quizIdParams', { suspense: true });
+  const quizIdParams = usePathParam('quizIdParams', { suspense: true });
 
-  const { data: quiz } = useQuery(QUERY_KEYS.GET_QUIZ_BY_ID, () => getQuizById(quizIdParams), {
+  const { data: quiz } = useQuery([QUERY_KEYS.GET_QUIZ_BY_ID], () => getQuizById(quizIdParams), {
     enabled: Boolean(quizIdParams),
   });
   if (!quiz) {

--- a/service/src/quiz/pages/QuizSolvingPage/index.tsx
+++ b/service/src/quiz/pages/QuizSolvingPage/index.tsx
@@ -13,7 +13,7 @@ import { StudyPeerAnswer } from './components/StudyPeerAnswer';
 export default function QuizSolvingPage() {
   const quizIdParams = usePathParam('quizIdParams', { suspense: true });
 
-  const { data: quiz } = useQuery([QUERY_KEYS.GET_QUIZ_BY_ID], () => getQuizById(quizIdParams), {
+  const { data: quiz } = useQuery(QUERY_KEYS.GET_QUIZ_BY_ID(quizIdParams), () => getQuizById(quizIdParams), {
     enabled: Boolean(quizIdParams),
   });
   if (!quiz) {

--- a/service/src/quiz/pages/QuizVotingPage/index.tsx
+++ b/service/src/quiz/pages/QuizVotingPage/index.tsx
@@ -1,15 +1,15 @@
 import { useQueryParam } from '@depromeet/utils';
 import { Flex, Spacing } from '@toss/emotion-utils';
+import { useQuery } from 'react-query';
 
 import { QuizNav } from 'quiz/common/components/QuizNav';
 import { QuizQuestion } from 'quiz/common/components/QuizQuestion';
+import { getQuizById } from 'quiz/common/components/QuizQuestion/remotes/quiz';
+import { QUERY_KEYS } from 'quiz/constants/queryKeys';
 
 import { MyAnswerViewer } from './components/MyAnswerViewer';
 import { PeerAnswerList } from './components/PeerAnswerList';
 import { VoteSubmitButton } from './components/VoteSubmitButton';
-import { useQuery } from 'react-query';
-import { QUERY_KEYS } from 'quiz/constants/queryKeys';
-import { getQuizById } from 'quiz/common/components/QuizQuestion/remotes/quiz';
 
 export default function QuizVotingPage() {
   const quizIdParams = useQueryParam('quizIdParams', { suspense: true });

--- a/service/src/quiz/pages/QuizVotingPage/index.tsx
+++ b/service/src/quiz/pages/QuizVotingPage/index.tsx
@@ -1,3 +1,4 @@
+import { useQueryParam } from '@depromeet/utils';
 import { Flex, Spacing } from '@toss/emotion-utils';
 
 import { QuizNav } from 'quiz/common/components/QuizNav';
@@ -6,8 +7,19 @@ import { QuizQuestion } from 'quiz/common/components/QuizQuestion';
 import { MyAnswerViewer } from './components/MyAnswerViewer';
 import { PeerAnswerList } from './components/PeerAnswerList';
 import { VoteSubmitButton } from './components/VoteSubmitButton';
+import { useQuery } from 'react-query';
+import { QUERY_KEYS } from 'quiz/constants/queryKeys';
+import { getQuizById } from 'quiz/common/components/QuizQuestion/remotes/quiz';
 
 export default function QuizVotingPage() {
+  const quizIdParams = useQueryParam('quizIdParams', { suspense: true });
+
+  const { data: quiz } = useQuery(QUERY_KEYS.GET_QUIZ_BY_ID, () => getQuizById(quizIdParams), {
+    enabled: Boolean(quizIdParams),
+  });
+  if (!quiz) {
+    return null;
+  }
   return (
     <>
       <QuizNav mainTitle="똑표 하기" studyId={1} />

--- a/service/src/quiz/pages/QuizVotingPage/index.tsx
+++ b/service/src/quiz/pages/QuizVotingPage/index.tsx
@@ -1,4 +1,4 @@
-import { useQueryParam } from '@depromeet/utils';
+import { usePathParam } from '@depromeet/utils';
 import { Flex, Spacing } from '@toss/emotion-utils';
 import { useQuery } from 'react-query';
 
@@ -12,9 +12,9 @@ import { PeerAnswerList } from './components/PeerAnswerList';
 import { VoteSubmitButton } from './components/VoteSubmitButton';
 
 export default function QuizVotingPage() {
-  const quizIdParams = useQueryParam('quizIdParams', { suspense: true });
+  const quizIdParams = usePathParam('quizIdParams', { suspense: true });
 
-  const { data: quiz } = useQuery(QUERY_KEYS.GET_QUIZ_BY_ID, () => getQuizById(quizIdParams), {
+  const { data: quiz } = useQuery([QUERY_KEYS.GET_QUIZ_BY_ID], () => getQuizById(quizIdParams), {
     enabled: Boolean(quizIdParams),
   });
   if (!quiz) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2753,6 +2753,7 @@ __metadata:
     "@toss/react": ^1.3.0
     "@toss/react-query": ^1.1.0
     "@toss/use-overlay": ^1.1.0
+    "@toss/use-query-param": ^1.1.3
     "@toss/utils": ^1.3.0
     "@types/node": 18.11.9
     "@types/react": ^18.0.17


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->
- 퀴즈 생성 페이지에 navbar를 추가했습니다. 
- navbar의 뒤로가기 버튼을 눌렀을 때 스터디 상세 페이지로 이동하도록 구현했습니다. 

## 💁 무엇이 어떻게 바뀌나요?
- 디자인 레퍼런스: 
- 관련 슬랙 링크: 

## 💬 리뷰어분들께 
<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!-- 
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->