### PR TITLE
feat(@depromeet/toks-components): 스터디 링크 복사 기능 헤더에 추가

### DIFF
--- a/shared/layout/src/components/Layout.tsx
+++ b/shared/layout/src/components/Layout.tsx
@@ -36,8 +36,7 @@ function Component({ children, fullWidth = true }: { children: ReactNode; fullWi
   });
 
   const isNonMember = user == null;
-  console.log(router.pathname)
-  console.log(checkShowCopyLinkButton(router.pathname, ['/quiz/study-detail']))
+
   return (
     <>
       {isNonMember ? (

--- a/shared/layout/src/components/Layout.tsx
+++ b/shared/layout/src/components/Layout.tsx
@@ -12,8 +12,7 @@ import { useMutation } from 'react-query';
 
 import { UserMenu } from './UserMenu';
 
-const checkShowCopyLinkButton = (routerPath: string, paths: string[]) =>
-  paths.some(path => routerPath.includes(path))
+const checkShowCopyLinkButton = (routerPath: string, paths: string[]) => paths.some(path => routerPath.includes(path));
 
 function Component({ children, fullWidth = true }: { children: ReactNode; fullWidth?: boolean }) {
   const { data: user, refetch } = useSafelyGetUser();
@@ -71,9 +70,7 @@ function Component({ children, fullWidth = true }: { children: ReactNode; fullWi
           imgUrl={user.profileImageUrl}
           userName={user.nickname}
           login
-          showCopyLinkButton={
-            checkShowCopyLinkButton(router.pathname, ['/quiz/study-detail'])
-          }
+          showCopyLinkButton={checkShowCopyLinkButton(router.pathname, ['/quiz/study-detail'])}
           onClickButton={() => {
             if (isLoading) {
               return;

--- a/shared/layout/src/components/Layout.tsx
+++ b/shared/layout/src/components/Layout.tsx
@@ -12,6 +12,9 @@ import { useMutation } from 'react-query';
 
 import { UserMenu } from './UserMenu';
 
+const checkShowCopyLinkButton = (routerPath: string, paths: string[]) =>
+  paths.some(path => routerPath.includes(path))
+
 function Component({ children, fullWidth = true }: { children: ReactNode; fullWidth?: boolean }) {
   const { data: user, refetch } = useSafelyGetUser();
   const { toggle, close } = useUserMenuDialog();
@@ -33,7 +36,8 @@ function Component({ children, fullWidth = true }: { children: ReactNode; fullWi
   });
 
   const isNonMember = user == null;
-
+  console.log(router.pathname)
+  console.log(checkShowCopyLinkButton(router.pathname, ['/quiz/study-detail']))
   return (
     <>
       {isNonMember ? (
@@ -68,6 +72,9 @@ function Component({ children, fullWidth = true }: { children: ReactNode; fullWi
           imgUrl={user.profileImageUrl}
           userName={user.nickname}
           login
+          showCopyLinkButton={
+            checkShowCopyLinkButton(router.pathname, ['/quiz/study-detail'])
+          }
           onClickButton={() => {
             if (isLoading) {
               return;

--- a/shared/toks-components/src/components/Icon/index.tsx
+++ b/shared/toks-components/src/components/Icon/index.tsx
@@ -23,10 +23,11 @@ export const Icon = ({ color, size = 28, width, height, iconName, wrapperProps, 
   );
 };
 
+// TODO: svg파일의 색깔이 fill아니면 stroke으로 칠해져 있는게 있어서 둘 다 지원 필요
 const StyledIcon = styled.i<{ color?: KeyOfColors }>`
   & > svg,
   & path {
-    fill: ${({ color }) => color && theme.colors[color]};
+    stroke: ${({ color }) => color && theme.colors[color]};
   }
   display: inline-flex;
   align-items: center;

--- a/shared/toks-components/src/components/ToksHeader/index.tsx
+++ b/shared/toks-components/src/components/ToksHeader/index.tsx
@@ -1,7 +1,9 @@
 import { theme } from '@depromeet/theme';
 import styled from '@emotion/styled';
+import { ButtonHTMLAttributes } from 'react';
 
 import { BP, MAX_WIDTH, MIN_WIDTH, TOKS_HEADER_HEIGHT, emoji } from '../../constants';
+import { useClipboard } from '../../hooks';
 import { Icon } from '../Icon';
 import { Image } from '../Image';
 import { Text } from '../Text';
@@ -37,6 +39,14 @@ const KAKAO_BASE_IMAGE = 'http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1Y
 const BASE_IMAGE = 'https://toks-web-assets.s3.amazonaws.com/toks-emoji/ic-base-profile.png';
 
 export function ToksHeader({ showCopyLinkButton= false, onClickLogo, ...rest }: HeaderProps) {
+  const { copyToClipboard } = useClipboard();
+  const getStudyId = () => {
+    const splitedPathname = window.location.pathname.split('/')
+    const studyDetailIndex = splitedPathname.findIndex(path => path === 'study-detail')
+    return Number(splitedPathname[studyDetailIndex + 1]);
+  }
+  const inviteLink = showCopyLinkButton? `${window.location.origin}/home/join-study/${getStudyId()}` : `${window.location.origin}/login`;
+  
   return (
     <Header>
       <ClickableImage
@@ -47,15 +57,19 @@ export function ToksHeader({ showCopyLinkButton= false, onClickLogo, ...rest }: 
         height={24}
         onClick={onClickLogo}
       />
-      {showCopyLinkButton && <StudyLinkCopyButton/>}
+      {
+        showCopyLinkButton && 
+          <StudyLinkCopyButton
+            onClick={() => copyToClipboard(inviteLink)}/>
+      }
       <ProfileButton {...rest} />
     </Header>
   );
 }
 
-function StudyLinkCopyButton() {
+function StudyLinkCopyButton({onClick} : ButtonHTMLAttributes<HTMLButtonElement>) {
   return (
-    <CopyButton>
+    <CopyButton onClick={onClick}>
       <Icon color='gray070' size={28} iconName="ic-link" />
       <Text color='gray070' variant="subhead">스터디 링크 복사</Text>
     </CopyButton>

--- a/shared/toks-components/src/components/ToksHeader/index.tsx
+++ b/shared/toks-components/src/components/ToksHeader/index.tsx
@@ -38,15 +38,17 @@ function isMember(props: ProfileButtonProps): props is MemberProps {
 const KAKAO_BASE_IMAGE = 'http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg';
 const BASE_IMAGE = 'https://toks-web-assets.s3.amazonaws.com/toks-emoji/ic-base-profile.png';
 
-export function ToksHeader({ showCopyLinkButton= false, onClickLogo, ...rest }: HeaderProps) {
+export function ToksHeader({ showCopyLinkButton = false, onClickLogo, ...rest }: HeaderProps) {
   const { copyToClipboard } = useClipboard();
   const getStudyId = () => {
-    const splitedPathname = window.location.pathname.split('/')
-    const studyDetailIndex = splitedPathname.findIndex(path => path === 'study-detail')
+    const splitedPathname = window.location.pathname.split('/');
+    const studyDetailIndex = splitedPathname.findIndex(path => path === 'study-detail');
     return Number(splitedPathname[studyDetailIndex + 1]);
-  }
-  const inviteLink = showCopyLinkButton? `${window.location.origin}/home/join-study/${getStudyId()}` : `${window.location.origin}/login`;
-  
+  };
+  const inviteLink = showCopyLinkButton
+    ? `${window.location.origin}/home/join-study/${getStudyId()}`
+    : `${window.location.origin}/login`;
+
   return (
     <Header>
       <ClickableImage
@@ -57,23 +59,21 @@ export function ToksHeader({ showCopyLinkButton= false, onClickLogo, ...rest }: 
         height={24}
         onClick={onClickLogo}
       />
-      {
-        showCopyLinkButton && 
-          <StudyLinkCopyButton
-            onClick={() => copyToClipboard(inviteLink)}/>
-      }
+      {showCopyLinkButton && <StudyLinkCopyButton onClick={() => copyToClipboard(inviteLink)} />}
       <ProfileButton {...rest} />
     </Header>
   );
 }
 
-function StudyLinkCopyButton({onClick} : ButtonHTMLAttributes<HTMLButtonElement>) {
+function StudyLinkCopyButton({ onClick }: ButtonHTMLAttributes<HTMLButtonElement>) {
   return (
     <CopyButton onClick={onClick}>
-      <Icon color='gray070' size={28} iconName="ic-link" />
-      <Text color='gray070' variant="subhead">스터디 링크 복사</Text>
+      <Icon color="gray070" size={28} iconName="ic-link" />
+      <Text color="gray070" variant="subhead">
+        스터디 링크 복사
+      </Text>
     </CopyButton>
-  )
+  );
 }
 
 function ProfileButton(props: ProfileButtonProps) {

--- a/shared/toks-components/src/components/ToksHeader/index.tsx
+++ b/shared/toks-components/src/components/ToksHeader/index.tsx
@@ -2,6 +2,7 @@ import { theme } from '@depromeet/theme';
 import styled from '@emotion/styled';
 
 import { BP, MAX_WIDTH, MIN_WIDTH, TOKS_HEADER_HEIGHT, emoji } from '../../constants';
+import { Icon } from '../Icon';
 import { Image } from '../Image';
 import { Text } from '../Text';
 
@@ -44,9 +45,19 @@ export function ToksHeader({ onClickLogo, ...rest }: HeaderProps) {
         height={24}
         onClick={onClickLogo}
       />
+      <StudyLinkCopyButton/>
       <ProfileButton {...rest} />
     </Header>
   );
+}
+
+function StudyLinkCopyButton() {
+  return (
+    <CopyButton>
+      <Icon color='gray070' size={28} iconName="ic-link" />
+      <Text color='gray070' variant="subhead">스터디 링크 복사</Text>
+    </CopyButton>
+  )
 }
 
 function ProfileButton(props: ProfileButtonProps) {
@@ -146,6 +157,14 @@ const Button = styled.button`
   &:hover {
     cursor: pointer;
   }
+`;
+
+const CopyButton = styled.button`
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin-left: auto;
+  margin-right: 35px;
 `;
 
 const ClickableImage = styled(Image)`

--- a/shared/toks-components/src/components/ToksHeader/index.tsx
+++ b/shared/toks-components/src/components/ToksHeader/index.tsx
@@ -9,6 +9,7 @@ import { Text } from '../Text';
 type MemberProps = {
   imgUrl: string;
   userName: string;
+  showCopyLinkButton?: boolean;
   onClickButton: VoidFunction;
   onClickLogo: VoidFunction;
   login: true;
@@ -16,6 +17,7 @@ type MemberProps = {
 
 type NonMemberProps = {
   login: false;
+  showCopyLinkButton?: boolean;
   onClickButton: VoidFunction;
   onClickLogo: VoidFunction;
 };
@@ -34,7 +36,7 @@ function isMember(props: ProfileButtonProps): props is MemberProps {
 const KAKAO_BASE_IMAGE = 'http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg';
 const BASE_IMAGE = 'https://toks-web-assets.s3.amazonaws.com/toks-emoji/ic-base-profile.png';
 
-export function ToksHeader({ onClickLogo, ...rest }: HeaderProps) {
+export function ToksHeader({ showCopyLinkButton= false, onClickLogo, ...rest }: HeaderProps) {
   return (
     <Header>
       <ClickableImage
@@ -45,7 +47,7 @@ export function ToksHeader({ onClickLogo, ...rest }: HeaderProps) {
         height={24}
         onClick={onClickLogo}
       />
-      <StudyLinkCopyButton/>
+      {showCopyLinkButton && <StudyLinkCopyButton/>}
       <ProfileButton {...rest} />
     </Header>
   );


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
- 스터디 상세 화면에서 스터디 링크 복사 기능이 필요해서 헤더에 추가 하였습니다.
- 헤더에 showCopyLinkButton라는 props를 추가해서 true값을 넘기면 해당 버튼이 등장합니다.
- 버튼이 등장하는 로직은 Layout컴포넌트에 구현하였습니다. checkShowCopyLinkButton 함수에 router path와 해당 버튼이 등장해야하는 페이지의 path를 적으면 됩니다.
- 현재 디자인으로는 스터디 상세 페이지에만 해당 버튼이 있지만, 다른 페이지에도 헤더에 해당 버튼이 등장해야할 것을 고려해서 위와 같이 구현했습니다.
<img width="574" alt="스크린샷 2023-01-12 오후 6 00 49" src="https://user-images.githubusercontent.com/47452547/212023240-0d22d95e-826e-4c1f-80e9-8094c3f8f1a1.png">

## 💁 무엇이 어떻게 바뀌나요?
- 디자인 레퍼런스: 
- 관련 슬랙 링크: 

## 💬 리뷰어분들께 
1. 헤더에는 버튼이 보일지 말지에 대한 props만 받게하고 버튼이 등장하는 페이지인지 확인하는 로직은 Layout에서 담당 (현재 구현한 방법)
2. 헤더에서 window.location.pathname을 사용하여 1번의 로직을 전부 담당
1번으로 구현했는데 2번의 방법이 돌이켜 보니 더 적절한것 같기도 하네요 ㅠ

<!-- 
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->