### PR TITLE
refactor(@depromeet/toks-components): Tag 컴포넌트의 프라임 리액트 의존 제거, maxView props 추가

### DIFF
--- a/service/src/home/pages/JoinStudy/components/JoinStudyBox/index.tsx
+++ b/service/src/home/pages/JoinStudy/components/JoinStudyBox/index.tsx
@@ -78,7 +78,7 @@ export function JoinStudyBox() {
             <Spacing size={8} />
             <Tag.Row>
               {study.tags.map(({ id, name }) => (
-                <Tag key={id}>{name}</Tag>
+                <Tag key={id} value={name} />
               ))}
             </Tag.Row>
           </>

--- a/service/src/onboarding/pages/CreateComplete/components/StudyInfoBox/index.tsx
+++ b/service/src/onboarding/pages/CreateComplete/components/StudyInfoBox/index.tsx
@@ -43,7 +43,7 @@ export const StudyInfoBox = () => {
             <Spacing size={8} />
             <Tag.Row>
               {tags?.map(({ id, name }) => (
-                <Tag key={id}>{name}</Tag>
+                <Tag key={id} value={name}/>
               ))}
             </Tag.Row>
           </>

--- a/service/src/onboarding/pages/CreateComplete/components/StudyInfoBox/index.tsx
+++ b/service/src/onboarding/pages/CreateComplete/components/StudyInfoBox/index.tsx
@@ -43,7 +43,7 @@ export const StudyInfoBox = () => {
             <Spacing size={8} />
             <Tag.Row>
               {tags?.map(({ id, name }) => (
-                <Tag key={id} value={name}/>
+                <Tag key={id} value={name} />
               ))}
             </Tag.Row>
           </>

--- a/shared/toks-components/src/components/Tag/index.tsx
+++ b/shared/toks-components/src/components/Tag/index.tsx
@@ -1,34 +1,44 @@
-import { theme } from '@depromeet/theme';
+import { KeyOfColors, theme } from '@depromeet/theme';
 import styled from '@emotion/styled';
-import { Tag as BaseTag } from 'primereact/tag';
-import { ComponentProps, HTMLAttributes, ReactNode } from 'react';
+import {css} from '@emotion/react';
+// import { Tag as BaseTag } from 'primereact/tag';
+import { HTMLAttributes, ReactNode } from 'react';
+import { Text } from '../Text';
 
-interface TagProps extends Omit<ComponentProps<typeof BaseTag>, 'color'> {
-  color?: 'highlight' | 'normal';
+type TagColor = 'highlight' | 'normal'
+
+type TagColorMap = {
+  [key in TagColor]: {
+    background: string,
+    color: KeyOfColors
+  };
+};
+
+interface TagProps extends HTMLAttributes<HTMLSpanElement> {
+  value: string;
+  color?: TagColor;
 }
 
-export function Tag({ color = 'normal', ...restProps }: TagProps) {
+const TAG_COLOR : TagColorMap = {
+  normal : {
+    background : theme.colors.gray080,
+    color : 'gray020'
+  },
+  highlight : {
+    background : theme.colors.primary_opacity,
+    color : 'primary'
+  }
+}
+
+export function Tag({ value, color = 'normal', ...restProps }: TagProps) {
   return (
-    <BaseTag
-      // TODO: inline style로 적용한 부분 제외하기
-      style={{
-        background: color === 'highlight' ? 'rgba(255, 134, 47, 0.2)' : theme.colors.gray080,
-        color: color === 'highlight' ? theme.colors.primary : theme.colors.gray020,
-        padding: '4px 12px',
-        width: 'fit-content',
-        height: '28px',
-        borderRadius: '8px',
-        whiteSpace: 'nowrap',
-        fontFamily: 'Spoqa Han Sans Neo',
-        fontSize: '14px',
-        fontWeight: '400',
-        lineHeight: '20px',
-        letterSpacing: ' -0.6px',
-        textAlign: 'left',
-      }}
+    <StyledTag
+      color={color}
       role="listitem"
       {...restProps}
-    />
+    >
+      <Text variant='body02' color={TAG_COLOR[color].color}>{value}</Text>
+    </StyledTag>
   );
 }
 
@@ -42,6 +52,20 @@ function Row({ children, ...props }: RowProps) {
 }
 
 Tag.Row = Row;
+
+const StyledTag = styled.span<{color : TagColor}>`
+  padding: '4px 12px';
+  width: '200px';
+  height: '28px';
+  border-radius: '8px';
+  white-space: 'nowrap';
+  letter-spacing: ' -0.6px';
+  text-align: 'left';
+  ${({color}) => css`
+    background: ${TAG_COLOR[color].background};
+    color: ${TAG_COLOR[color].color};
+  `}
+`
 
 const ListRow = styled.ul`
   display: flex;

--- a/shared/toks-components/src/components/Tag/index.tsx
+++ b/shared/toks-components/src/components/Tag/index.tsx
@@ -1,7 +1,6 @@
 import { KeyOfColors, theme } from '@depromeet/theme';
 import styled from '@emotion/styled';
 import {css} from '@emotion/react';
-// import { Tag as BaseTag } from 'primereact/tag';
 import { HTMLAttributes, ReactNode } from 'react';
 import { Text } from '../Text';
 
@@ -30,11 +29,33 @@ const TAG_COLOR : TagColorMap = {
   }
 }
 
+const StyledTag = styled.span<{color : TagColor}>`
+  /* TODO : 이걸 살려서 적용이 되게 변경해야 함.
+  padding: '4px 12px';
+  width: 'fit-content';
+  height: '28px';
+  border-radius: '8px';
+  white-space: 'nowrap';
+  letter-spacing: ' -0.6px';
+  text-align: 'left';
+  */
+  ${({color}) => css`
+    background: ${TAG_COLOR[color].background};
+    color: ${TAG_COLOR[color].color};
+  `}
+`
+
 export function Tag({ value, color = 'normal', ...restProps }: TagProps) {
   return (
     <StyledTag
       color={color}
       role="listitem"
+      style={{
+        padding: '4px 12px',
+        width: 'fit-content',
+        borderRadius: '8px',
+        whiteSpace: 'nowrap',
+      }}
       {...restProps}
     >
       <Text variant='body02' color={TAG_COLOR[color].color}>{value}</Text>
@@ -52,20 +73,6 @@ function Row({ children, ...props }: RowProps) {
 }
 
 Tag.Row = Row;
-
-const StyledTag = styled.span<{color : TagColor}>`
-  padding: '4px 12px';
-  width: '200px';
-  height: '28px';
-  border-radius: '8px';
-  white-space: 'nowrap';
-  letter-spacing: ' -0.6px';
-  text-align: 'left';
-  ${({color}) => css`
-    background: ${TAG_COLOR[color].background};
-    color: ${TAG_COLOR[color].color};
-  `}
-`
 
 const ListRow = styled.ul`
   display: flex;

--- a/shared/toks-components/src/components/Tag/index.tsx
+++ b/shared/toks-components/src/components/Tag/index.tsx
@@ -44,11 +44,7 @@ const StyledTag = styled.span<{ color: TagColor }>`
 
 export function Tag({ value, color = 'normal', ...restProps }: TagProps) {
   return (
-    <StyledTag
-      color={color}
-      role="listitem"
-      {...restProps}
-    >
+    <StyledTag color={color} role="listitem" {...restProps}>
       <Text variant="body02" color={TAG_COLOR[color].color}>
         {value}
       </Text>

--- a/shared/toks-components/src/components/Tag/index.tsx
+++ b/shared/toks-components/src/components/Tag/index.tsx
@@ -31,15 +31,11 @@ const TAG_COLOR: TagColorMap = {
 };
 
 const StyledTag = styled.span<{ color: TagColor }>`
-  /* TODO : 이걸 살려서 적용이 되게 변경해야 함.
-  padding: '4px 12px';
-  width: 'fit-content';
-  height: '28px';
-  border-radius: '8px';
-  white-space: 'nowrap';
-  letter-spacing: ' -0.6px';
-  text-align: 'left';
-  */
+  padding: 4px 12px;
+  width: fit-content;
+  height: 28px;
+  border-radius: 8px;
+  white-space: nowrap;
   ${({ color }) => css`
     background: ${TAG_COLOR[color].background};
     color: ${TAG_COLOR[color].color};
@@ -51,12 +47,6 @@ export function Tag({ value, color = 'normal', ...restProps }: TagProps) {
     <StyledTag
       color={color}
       role="listitem"
-      style={{
-        padding: '4px 12px',
-        width: 'fit-content',
-        borderRadius: '8px',
-        whiteSpace: 'nowrap',
-      }}
       {...restProps}
     >
       <Text variant="body02" color={TAG_COLOR[color].color}>

--- a/shared/toks-components/src/components/Tag/index.tsx
+++ b/shared/toks-components/src/components/Tag/index.tsx
@@ -1,15 +1,16 @@
 import { KeyOfColors, theme } from '@depromeet/theme';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import {css} from '@emotion/react';
-import { HTMLAttributes, ReactNode } from 'react';
+import { Children, HTMLAttributes, ReactElement, ReactNode } from 'react';
+
 import { Text } from '../Text';
 
-type TagColor = 'highlight' | 'normal'
+type TagColor = 'highlight' | 'normal';
 
 type TagColorMap = {
   [key in TagColor]: {
-    background: string,
-    color: KeyOfColors
+    background: string;
+    color: KeyOfColors;
   };
 };
 
@@ -18,18 +19,18 @@ interface TagProps extends HTMLAttributes<HTMLSpanElement> {
   color?: TagColor;
 }
 
-const TAG_COLOR : TagColorMap = {
-  normal : {
-    background : theme.colors.gray080,
-    color : 'gray020'
+const TAG_COLOR: TagColorMap = {
+  normal: {
+    background: theme.colors.gray080,
+    color: 'gray020',
   },
-  highlight : {
-    background : theme.colors.primary_opacity,
-    color : 'primary'
-  }
-}
+  highlight: {
+    background: theme.colors.primary_opacity,
+    color: 'primary',
+  },
+};
 
-const StyledTag = styled.span<{color : TagColor}>`
+const StyledTag = styled.span<{ color: TagColor }>`
   /* TODO : 이걸 살려서 적용이 되게 변경해야 함.
   padding: '4px 12px';
   width: 'fit-content';
@@ -39,11 +40,11 @@ const StyledTag = styled.span<{color : TagColor}>`
   letter-spacing: ' -0.6px';
   text-align: 'left';
   */
-  ${({color}) => css`
+  ${({ color }) => css`
     background: ${TAG_COLOR[color].background};
     color: ${TAG_COLOR[color].color};
   `}
-`
+`;
 
 export function Tag({ value, color = 'normal', ...restProps }: TagProps) {
   return (
@@ -58,18 +59,22 @@ export function Tag({ value, color = 'normal', ...restProps }: TagProps) {
       }}
       {...restProps}
     >
-      <Text variant='body02' color={TAG_COLOR[color].color}>{value}</Text>
+      <Text variant="body02" color={TAG_COLOR[color].color}>
+        {value}
+      </Text>
     </StyledTag>
   );
 }
 
 interface RowProps extends HTMLAttributes<HTMLUListElement> {
+  maxView?: number;
   children: ReactNode;
 }
 
 // TODO: maxView 개수 받도록
-function Row({ children, ...props }: RowProps) {
-  return <ListRow {...props}>{children}</ListRow>;
+function Row({ children, maxView, ...props }: RowProps) {
+  const tags = Children.toArray(children) as ReactElement[];
+  return <ListRow {...props}>{maxView ? tags.slice(0, maxView) : tags}</ListRow>;
 }
 
 Tag.Row = Row;


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
- Tag 컴포넌트의 프라임 리액트 의존을 제거했습니다
- 태그의 색상 관리를 TagColorMap을 사용하여 해결했습니다
- maxView를 props를 Row에서 받으면 원하는 만큼만 태그를 보여줄 수 있습니다

## 💁 무엇이 어떻게 바뀌나요?
- 디자인 레퍼런스: 
- 관련 슬랙 링크: 

## 💬 리뷰어분들께 
<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!-- 
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->