### PR TITLE
fix(avatar) : 아바타 컴포넌트 기본이미지 문제, 기본이미지 회색 캐릭터로 변경

### DIFF
--- a/service/src/quiz/pages/StudyDetailPage/components/QuizItem/index.tsx
+++ b/service/src/quiz/pages/StudyDetailPage/components/QuizItem/index.tsx
@@ -219,9 +219,9 @@ export function QuizItem({ round, quiz, setQuizItemStatus }: QuizItemProps) {
                     똑스 안 푼 사람
                   </Text>
                 )}
-                <Avatar.Group>
+                <Avatar.Group size="medium" >
                   {unSubmitters.map(({ userId, profileImageUrl, nickname }) => (
-                    <Avatar key={userId} src={profileImageUrl} tooltipContent={nickname} size="medium" alt={nickname} />
+                    <Avatar key={userId} src={profileImageUrl} tooltipContent={nickname} alt={nickname} />
                   ))}
                 </Avatar.Group>
               </FlexRow>

--- a/service/src/quiz/pages/StudyDetailPage/components/QuizItem/index.tsx
+++ b/service/src/quiz/pages/StudyDetailPage/components/QuizItem/index.tsx
@@ -219,7 +219,7 @@ export function QuizItem({ round, quiz, setQuizItemStatus }: QuizItemProps) {
                     똑스 안 푼 사람
                   </Text>
                 )}
-                <Avatar.Group size="medium" >
+                <Avatar.Group size="medium">
                   {unSubmitters.map(({ userId, profileImageUrl, nickname }) => (
                     <Avatar key={userId} src={profileImageUrl} tooltipContent={nickname} alt={nickname} />
                   ))}

--- a/service/src/quiz/pages/StudyDetailPage/components/QuizItem/index.tsx
+++ b/service/src/quiz/pages/StudyDetailPage/components/QuizItem/index.tsx
@@ -207,7 +207,7 @@ export function QuizItem({ round, quiz, setQuizItemStatus }: QuizItemProps) {
               <Text variant="subhead" css={{ margin: '0 24px 0 0' }} as="h6">
                 똑스 만든사람
               </Text>
-              <Avatar src={creator.profileImageUrl} tooltipContent={creator.nickname} size="large" alt="제작자" />
+              <Avatar src={creator.profileImageUrl} tooltipContent={creator.nickname} size="medium" alt="제작자" />
               <Space css={{ flex: 1 }} />
               <FlexRow
                 css={{
@@ -221,7 +221,7 @@ export function QuizItem({ round, quiz, setQuizItemStatus }: QuizItemProps) {
                 )}
                 <Avatar.Group>
                   {unSubmitters.map(({ userId, profileImageUrl, nickname }) => (
-                    <Avatar key={userId} src={profileImageUrl} tooltipContent={nickname} size="large" alt={nickname} />
+                    <Avatar key={userId} src={profileImageUrl} tooltipContent={nickname} size="medium" alt={nickname} />
                   ))}
                 </Avatar.Group>
               </FlexRow>

--- a/service/src/quiz/pages/StudyDetailPage/components/RankingItem/index.tsx
+++ b/service/src/quiz/pages/StudyDetailPage/components/RankingItem/index.tsx
@@ -26,7 +26,7 @@ export function RankingItem({ rankItem }: RankingItemProps) {
           {convertNoneRanking(ranking)}
         </Text>
       )}
-      <Avatar src={user.profileImageUrl} size="large" alt={user.nickname} />
+      <Avatar src={user.profileImageUrl} size="medium" alt={user.nickname} />
       <Text
         variant="body01"
         color="white"

--- a/service/src/quiz/pages/StudyDetailPage/components/StudyInfo/index.tsx
+++ b/service/src/quiz/pages/StudyDetailPage/components/StudyInfo/index.tsx
@@ -46,7 +46,7 @@ function StudyInfo({ studyId }: StudyInfoProps) {
           <Avatar.Group>
             {members &&
               members.map(({ userId, nickname, profileImageUrl }) => (
-                <Avatar key={userId} tooltipContent={nickname} src={profileImageUrl} size="large" alt={nickname} />
+                <Avatar key={userId} tooltipContent={nickname} src={profileImageUrl} size="small" alt={nickname} />
               ))}
           </Avatar.Group>
         </Footer>

--- a/service/src/quiz/pages/StudyDetailPage/components/StudyInfo/index.tsx
+++ b/service/src/quiz/pages/StudyDetailPage/components/StudyInfo/index.tsx
@@ -43,10 +43,10 @@ function StudyInfo({ studyId }: StudyInfoProps) {
         </Body>
         <Footer>
           {/* Avatar Group id가 여기서는 스터디 id가 되고 각 퀴즈에서는 퀴즈의 id가 됨 */}
-          <Avatar.Group>
+          <Avatar.Group size="medium">
             {members &&
               members.map(({ userId, nickname, profileImageUrl }) => (
-                <Avatar key={userId} tooltipContent={nickname} src={profileImageUrl} size="small" alt={nickname} />
+                <Avatar key={userId} tooltipContent={nickname} src={profileImageUrl} alt={nickname} />
               ))}
           </Avatar.Group>
         </Footer>

--- a/shared/layout/src/components/UserMenu.tsx
+++ b/shared/layout/src/components/UserMenu.tsx
@@ -1,5 +1,5 @@
 import { theme } from '@depromeet/theme';
-import { BP, Image, MAX_WIDTH, Text } from '@depromeet/toks-components';
+import { BP, Image, MAX_WIDTH, Text, imageUrl } from '@depromeet/toks-components';
 import styled from '@emotion/styled';
 import { Flex, Spacing } from '@toss/emotion-utils';
 
@@ -10,17 +10,14 @@ interface Props {
   handleLogout: VoidFunction;
 }
 
-const KAKAO_BASE_IMAGE = 'http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg';
-const BASE_IMAGE = 'https://toks-web-assets.s3.amazonaws.com/toks-emoji/ic-base-profile.png';
-
 export function UserMenu({ img, name, nickname, handleLogout }: Props) {
-  const hasIndividualProfile = img !== KAKAO_BASE_IMAGE;
+  const hasIndividualProfile = img !== imageUrl.baseKakao;
 
   return (
     <UserMenuCard>
       <UserInfo>
         <Image
-          src={hasIndividualProfile ? img : BASE_IMAGE}
+          src={hasIndividualProfile ? img : imageUrl.baseToks}
           alt=""
           width={40}
           height={40}

--- a/shared/toks-components/src/components/Avatar/index.tsx
+++ b/shared/toks-components/src/components/Avatar/index.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useEffect, useState } from 'react';
 
-import { Image as ImageComponent, Text, Tooltip } from '@depromeet/toks-components';
+import { Image as ImageComponent, Text, Tooltip, imageUrl } from '@depromeet/toks-components';
 
 import { AvatarGroup } from './AvatarGroup';
 import { AVATAR_SIZE } from './constants';
@@ -22,7 +22,7 @@ export interface AvatarProps {
 }
 
 export function Avatar({
-  src = 'https://toks-web-assets.s3.amazonaws.com/toks-emoji/ic-base-profile.png',
+  src = imageUrl.baseToks,
   isVisibleTooltip = false,
   tooltipContent,
   size = 'small',

--- a/shared/toks-components/src/components/Avatar/index.tsx
+++ b/shared/toks-components/src/components/Avatar/index.tsx
@@ -33,6 +33,7 @@ export function Avatar({
   ...rest
 }: AvatarProps) {
   const [isLoaded, setIsLoaded] = useState(false);
+  const isKakaoBaseUrl = (src: string) => src === imageUrl.baseKakao;
 
   useEffect(() => {
     const image = new Image();
@@ -55,7 +56,7 @@ export function Avatar({
                 block
                 width={AVATAR_SIZE[size]}
                 height={AVATAR_SIZE[size]}
-                src={src}
+                src={isKakaoBaseUrl(src) ? imageUrl.baseToks : src}
                 style={{
                   opacity: isLoaded ? 1 : 0,
                 }}
@@ -70,7 +71,7 @@ export function Avatar({
             block
             width={AVATAR_SIZE[size]}
             height={AVATAR_SIZE[size]}
-            src={src}
+            src={isKakaoBaseUrl(src) ? imageUrl.baseToks : src}
             style={{
               opacity: isLoaded ? 1 : 0,
             }}

--- a/shared/toks-components/src/components/Avatar/index.tsx
+++ b/shared/toks-components/src/components/Avatar/index.tsx
@@ -56,7 +56,7 @@ export function Avatar({
                 block
                 width={AVATAR_SIZE[size]}
                 height={AVATAR_SIZE[size]}
-                src={isKakaoBaseUrl(src) ? imageUrl.baseToks : src}
+                src={isKakaoBaseUrl(src) ? imageUrl.baseToksGrey : src}
                 style={{
                   opacity: isLoaded ? 1 : 0,
                 }}
@@ -71,7 +71,7 @@ export function Avatar({
             block
             width={AVATAR_SIZE[size]}
             height={AVATAR_SIZE[size]}
-            src={isKakaoBaseUrl(src) ? imageUrl.baseToks : src}
+            src={isKakaoBaseUrl(src) ? imageUrl.baseToksGrey : src}
             style={{
               opacity: isLoaded ? 1 : 0,
             }}

--- a/shared/toks-components/src/components/ToksHeader/index.tsx
+++ b/shared/toks-components/src/components/ToksHeader/index.tsx
@@ -3,7 +3,7 @@ import { colors } from '@depromeet/theme/dist/colors';
 import styled from '@emotion/styled';
 import { ButtonHTMLAttributes } from 'react';
 
-import { BP, imageUrl, MAX_WIDTH, MIN_WIDTH, TOKS_HEADER_HEIGHT } from '../../constants';
+import { BP, MAX_WIDTH, MIN_WIDTH, TOKS_HEADER_HEIGHT, imageUrl } from '../../constants';
 import { useClipboard } from '../../hooks';
 import { Icon } from '../Icon';
 import { Image } from '../Image';
@@ -105,13 +105,7 @@ function ProfileButton(props: ProfileButtonProps) {
 ToksHeader.Skeleton = function () {
   return (
     <Header>
-      <ClickableImage
-        src={imageUrl.logo}
-        alt="toks study"
-        draggable={false}
-        width={70}
-        height={24}
-      />
+      <ClickableImage src={imageUrl.logo} alt="toks study" draggable={false} width={70} height={24} />
     </Header>
   );
 };

--- a/shared/toks-components/src/components/ToksHeader/index.tsx
+++ b/shared/toks-components/src/components/ToksHeader/index.tsx
@@ -3,7 +3,7 @@ import { colors } from '@depromeet/theme/dist/colors';
 import styled from '@emotion/styled';
 import { ButtonHTMLAttributes } from 'react';
 
-import { BP, MAX_WIDTH, MIN_WIDTH, TOKS_HEADER_HEIGHT } from '../../constants';
+import { BP, imageUrl, MAX_WIDTH, MIN_WIDTH, TOKS_HEADER_HEIGHT } from '../../constants';
 import { useClipboard } from '../../hooks';
 import { Icon } from '../Icon';
 import { Image } from '../Image';
@@ -36,9 +36,6 @@ function isMember(props: ProfileButtonProps): props is MemberProps {
   return false;
 }
 
-const KAKAO_BASE_IMAGE = 'http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg';
-const BASE_IMAGE = 'https://toks-web-assets.s3.amazonaws.com/toks-emoji/ic-base-profile.png';
-
 export function ToksHeader({ showCopyLinkButton = false, onClickLogo, ...rest }: HeaderProps) {
   const { copyToClipboard } = useClipboard();
   const getStudyId = () => {
@@ -53,7 +50,7 @@ export function ToksHeader({ showCopyLinkButton = false, onClickLogo, ...rest }:
   return (
     <Header>
       <ClickableImage
-        src="https://asset.tokstudy.com/logo.png"
+        src={imageUrl.logo}
         alt="toks study"
         draggable={false}
         width={70}
@@ -88,7 +85,7 @@ function ProfileButton(props: ProfileButtonProps) {
     <Button onClick={onClickButton}>
       <ImageWrapper>
         <ClickableImage
-          src={imgUrl === KAKAO_BASE_IMAGE ? BASE_IMAGE : imgUrl}
+          src={imgUrl === imageUrl.baseKakao ? imageUrl.baseToks : imgUrl}
           alt=""
           width={22}
           height={22}
@@ -109,7 +106,7 @@ ToksHeader.Skeleton = function () {
   return (
     <Header>
       <ClickableImage
-        src="https://asset.tokstudy.com/logo.png"
+        src={imageUrl.logo}
         alt="toks study"
         draggable={false}
         width={70}

--- a/shared/toks-components/src/constants/image.ts
+++ b/shared/toks-components/src/constants/image.ts
@@ -1,0 +1,4 @@
+export const image = {
+  baseToks: 'https://asset.tokstudy.com/toks-emoji/ic-base-profile.png',
+  baseKakao: 'http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg',
+};

--- a/shared/toks-components/src/constants/imageUrl.ts
+++ b/shared/toks-components/src/constants/imageUrl.ts
@@ -1,4 +1,5 @@
-export const image = {
+export const imageUrl = {
   baseToks: 'https://asset.tokstudy.com/toks-emoji/ic-base-profile.png',
   baseKakao: 'http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg',
+  logo: 'https://asset.tokstudy.com/logo.png',
 };

--- a/shared/toks-components/src/constants/imageUrl.ts
+++ b/shared/toks-components/src/constants/imageUrl.ts
@@ -1,5 +1,6 @@
 export const imageUrl = {
   baseToks: 'https://asset.tokstudy.com/toks-emoji/ic-base-profile.png',
+  baseToksGrey: 'https://toks-web-assets.s3.amazonaws.com/ic-base-profile-grey.png',
   baseKakao: 'http://k.kakaocdn.net/dn/dpk9l1/btqmGhA2lKL/Oz0wDuJn1YV2DIn92f6DVK/img_640x640.jpg',
   logo: 'https://asset.tokstudy.com/logo.png',
 };

--- a/shared/toks-components/src/constants/index.ts
+++ b/shared/toks-components/src/constants/index.ts
@@ -1,2 +1,3 @@
 export * from './emoji';
 export * from './env';
+export * from './image';

--- a/shared/toks-components/src/constants/index.ts
+++ b/shared/toks-components/src/constants/index.ts
@@ -1,3 +1,3 @@
 export * from './emoji';
 export * from './env';
-export * from './image';
+export * from './imageUrl';


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
- 카톡 프로필이 기본 프로필일때 카톡 기본 이미지 그대로 나오는 문제를 해결하였습니다.
- 카톡 기본 프로필 이미지, 똑스 기본 프로필 이미지 url이 중복으로 계속 쓰여서 공통 constants 값으로 분리했습니다.
- 새로 바뀐 아바타 디자인에 의하여 회색 기본 이미지가 나오도록 변경했습니다.
- 확인결과 스터디 상세화면 기준 large크기가 medium으로 변경되어서 전부 변경해주었는데 다른 화면의 아바타에서도 변경이 필요한지 확인이 필요할 것 같아요
- 아바타 그룹을 사용할때는 크기를 아바타 그룹에 넣어주어야 해서 이 부분 역시 이에 맞게 변경하였습니다.
<img width="1308" alt="스크린샷 2023-03-08 오후 12 52 30" src="https://user-images.githubusercontent.com/47452547/223615329-d15ed50d-96f4-4a5f-a976-17db6f5f227f.png">


## 💁 무엇이 어떻게 바뀌나요?
- 디자인 레퍼런스: 
- 관련 슬랙 링크: 

## 💬 리뷰어분들께 
<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!-- 
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->