### PR TITLE
feat(home): Ready type card 수정

### DIFF
--- a/service/src/home/pages/MyStudies/components/StudyCard/index.tsx
+++ b/service/src/home/pages/MyStudies/components/StudyCard/index.tsx
@@ -6,7 +6,7 @@ import { Flex, Spacing, padding, width100 } from '@toss/emotion-utils';
 import { useRouter } from 'next/router';
 import { match } from 'ts-pattern';
 
-import { formatStartedAtToDecimalDay } from 'home/utils';
+import { formatStartedAtDay, formatStartedAtToDecimalDay } from 'home/utils';
 
 import { Study } from '../../models/study';
 
@@ -22,9 +22,10 @@ interface Props {
 }
 
 const LOTTIE_MAP = {
-  sleep: 'https://asset.tokstudy.com/lottie-toks-sleep.json',
-  awake: 'https://asset.tokstudy.com/lottie-toks-base.json',
-  graduated: 'https://asset.tokstudy.com/lottie-toks-graduated.json',
+  sleep: 'https://toks-web-assets.s3.amazonaws.com/lottie-toks-sleep.json',
+  awake: 'https://asset.tokstudy.com/lottie-toks-awake.json',
+  graduated: 'https://asset.tokstudy.com/lottie-toks-graduate.json',
+  wait: 'https://asset.tokstudy.com/lottie-toks-wait.json',
 } as const;
 
 function StudyCard({ title, tags, onClick, memberCount, quizStatus, studyStatus, studyId, startedAt }: Props) {
@@ -47,7 +48,6 @@ function StudyCard({ title, tags, onClick, memberCount, quizStatus, studyStatus,
             const diffDays = formatStartedAtToDecimalDay(startedAt);
             const text = `시작까지 ${diffDays}일 남았어요!`;
 
-            console.log(text);
             return <TextBallon title={text} />;
           }
         )
@@ -83,7 +83,6 @@ function StudyCard({ title, tags, onClick, memberCount, quizStatus, studyStatus,
         <Flex.Center
           css={{
             position: 'absolute',
-            boxShadow: studyStatus === 'FINISH' ? undefined : '0 0 30px #FEE101',
             border: 'none',
             borderRadius: '50%',
             top: '42px',
@@ -98,6 +97,10 @@ function StudyCard({ title, tags, onClick, memberCount, quizStatus, studyStatus,
               .when(
                 ({ quizStatus }) => quizStatus === 'UNCHECKED' || quizStatus === 'UNSOLVED',
                 () => LOTTIE_MAP.awake
+              )
+              .when(
+                ({ studyStatus }) => studyStatus === 'READY',
+                () => LOTTIE_MAP.wait
               )
               .otherwise(() => LOTTIE_MAP.sleep)}
             alt=""
@@ -121,27 +124,27 @@ function StudyCard({ title, tags, onClick, memberCount, quizStatus, studyStatus,
         </Tag.Row>
 
         <Spacing size={50} />
+        {studyStatus === 'READY' ? (
+          <Text variant="body01">{formatStartedAtDay(startedAt)}에 만나요</Text>
+        ) : (
+          <Button
+            type={match({ quizStatus, studyStatus })
+              .when(
+                ({ quizStatus }) => quizStatus === 'UNCHECKED',
+                () => 'primary' as const
+              )
+              .when(
+                ({ quizStatus }) => quizStatus === 'UNSOLVED',
+                () => 'primary' as const
+              )
 
-        <Button
-          type={match({ quizStatus, studyStatus })
-            .when(
-              ({ quizStatus }) => quizStatus === 'UNCHECKED',
-              () => 'primary' as const
-            )
-            .when(
-              ({ quizStatus }) => quizStatus === 'UNSOLVED',
-              () => 'primary' as const
-            )
-            .when(
-              ({ studyStatus }) => studyStatus === 'READY',
-              () => 'primary' as const
-            )
-            .otherwise(() => 'general' as const)}
-          css={{ justifySelf: 'flex-end' }}
-          onClick={onClick}
-        >
-          {studyStatus !== 'IN_PROGRESS' ? '복습하기' : '입장하기'}
-        </Button>
+              .otherwise(() => 'general' as const)}
+            css={{ justifySelf: 'flex-end' }}
+            onClick={onClick}
+          >
+            {studyStatus === 'FINISH' ? '복습하기' : '입장하기'}
+          </Button>
+        )}
       </Card>
     </div>
   );

--- a/service/src/home/utils.ts
+++ b/service/src/home/utils.ts
@@ -1,8 +1,13 @@
-import { differenceInDays } from 'date-fns';
+import { differenceInDays, format } from 'date-fns';
 
 export const formatStartedAtToDecimalDay = (startedAt: string) => {
   const today = new Date();
   const startedAtDate = new Date(startedAt);
 
   return differenceInDays(startedAtDate, today) + 1;
+};
+
+export const formatStartedAtDay = (startedAt: string) => {
+  const date = new Date(startedAt);
+  return format(date, 'yyyy.MM.dd');
 };


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->
- READY type card 버튼을 삭제하고 시작 예정일이 카드에 나타나도록 구현했습니다. 
- 변경된 lottie 파일로 교체하는 작업을 했습니다. 

## 💁 무엇이 어떻게 바뀌나요?
- 디자인 레퍼런스: 
![image](https://user-images.githubusercontent.com/89721027/224137096-e0b50947-37fa-48bb-abba-f2606d3efe4f.png)


## 💬 리뷰어분들께 
<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!-- 
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->