### PR TITLE
feat(QuizCreatePage) : 다시 만들기 클릭시 확인 모달 띄우기 구현

### DIFF
--- a/service/src/quiz/pages/QuizCreatePage/components/QuizCreateInputList/index.tsx
+++ b/service/src/quiz/pages/QuizCreatePage/components/QuizCreateInputList/index.tsx
@@ -19,17 +19,7 @@ interface QuizCreateInputListProps {
   reset: UseFormReset<QuizCreateForm>;
 }
 
-export const QuizCreateInputList = ({
-  register,
-  setValue,
-  watch,
-  endedAt,
-  className,
-  reset,
-  isLoading,
-}: QuizCreateInputListProps) => {
-  const uploadRef: ComponentProps<typeof Upload>['ref'] | null = useRef(null);
-
+const useConfirmModal = (confirmCallback: () => void) => {
   const { openModal, close } = useModal();
   const openConfirmModal = async () => {
     await openModal({
@@ -48,9 +38,9 @@ export const QuizCreateInputList = ({
         </Flex.Center>
       ),
       type: 'confirm',
+      buttonText: '다시 만들기',
       onConfirm: () => {
-        uploadRef.current?.reset();
-        reset();
+        confirmCallback();
         close();
       },
       onCancel: () => {
@@ -58,6 +48,24 @@ export const QuizCreateInputList = ({
       },
     });
   };
+
+  return { openConfirmModal, close };
+};
+
+export const QuizCreateInputList = ({
+  register,
+  setValue,
+  watch,
+  endedAt,
+  className,
+  reset,
+  isLoading,
+}: QuizCreateInputListProps) => {
+  const uploadRef: ComponentProps<typeof Upload>['ref'] | null = useRef(null);
+  const { openConfirmModal } = useConfirmModal(() => {
+    uploadRef.current?.reset();
+    reset();
+  });
   return (
     <Flex
       direction="column"

--- a/service/src/quiz/pages/QuizCreatePage/components/QuizCreateInputList/index.tsx
+++ b/service/src/quiz/pages/QuizCreatePage/components/QuizCreateInputList/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Calendar, DropDown, TimePicker, Upload } from '@depromeet/toks-components';
+import { Button, Calendar, DropDown, Text, TimePicker, Upload, useModal } from '@depromeet/toks-components';
 import { Flex, Spacing } from '@toss/emotion-utils';
 import { sub } from 'date-fns';
 import { ComponentProps, useRef } from 'react';
@@ -29,6 +29,35 @@ export const QuizCreateInputList = ({
   isLoading,
 }: QuizCreateInputListProps) => {
   const uploadRef: ComponentProps<typeof Upload>['ref'] | null = useRef(null);
+
+  const { openModal, close } = useModal();
+  const openConfirmModal = async () => {
+    await openModal({
+      children: (
+        <Flex.Center direction="column">
+          <Text variant="title03" as="h3" css={{ margin: 0 }}>
+            작성 중인 퀴즈가 있어요.
+          </Text>
+          <Text variant="title03" as="h3" css={{ margin: 0 }}>
+            다시 만드시겠어요?
+          </Text>
+          <Text variant="body01" as="span" css={{ marginTop: '8px' }}>
+            다시 만들 경우, 지금까지 작성한 퀴즈 내용는 다시 복구할 수 없어요.
+          </Text>
+          <Spacing size={56} />
+        </Flex.Center>
+      ),
+      type: 'confirm',
+      onConfirm: () => {
+        uploadRef.current?.reset();
+        reset();
+        close();
+      },
+      onCancel: () => {
+        close();
+      },
+    });
+  };
   return (
     <Flex
       direction="column"
@@ -75,8 +104,7 @@ export const QuizCreateInputList = ({
           htmlType="reset"
           type="ghost"
           onClick={() => {
-            uploadRef.current?.reset();
-            reset();
+            openConfirmModal();
           }}
         >
           다시 만들기

--- a/service/src/quiz/pages/QuizCreatePage/components/QuizCreateInputList/index.tsx
+++ b/service/src/quiz/pages/QuizCreatePage/components/QuizCreateInputList/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Calendar, DropDown, Text, TimePicker, Upload, useModal } from '@depromeet/toks-components';
+import { Button, Calendar, DropDown, TimePicker, Upload } from '@depromeet/toks-components';
 import { Flex, Spacing } from '@toss/emotion-utils';
 import { sub } from 'date-fns';
 import { ComponentProps, useRef } from 'react';
@@ -6,6 +6,7 @@ import { Control, FieldValues, UseFormRegister, UseFormReset, UseFormSetValue, U
 
 import { QUIZ_LIMIT_TIME } from 'quiz/pages/QuizCreatePage/constants';
 
+import { useConfirmModal } from '../../hooks/useConfirmModal';
 import { QuizCreateForm } from '../../types';
 
 interface QuizCreateInputListProps {
@@ -18,39 +19,6 @@ interface QuizCreateInputListProps {
   className?: string;
   reset: UseFormReset<QuizCreateForm>;
 }
-
-const useConfirmModal = (confirmCallback: () => void) => {
-  const { openModal, close } = useModal();
-  const openConfirmModal = async () => {
-    await openModal({
-      children: (
-        <Flex.Center direction="column">
-          <Text variant="title03" as="h3" css={{ margin: 0 }}>
-            작성 중인 퀴즈가 있어요.
-          </Text>
-          <Text variant="title03" as="h3" css={{ margin: 0 }}>
-            다시 만드시겠어요?
-          </Text>
-          <Text variant="body01" as="span" css={{ marginTop: '8px' }}>
-            다시 만들 경우, 지금까지 작성한 퀴즈 내용는 다시 복구할 수 없어요.
-          </Text>
-          <Spacing size={56} />
-        </Flex.Center>
-      ),
-      type: 'confirm',
-      buttonText: '다시 만들기',
-      onConfirm: () => {
-        confirmCallback();
-        close();
-      },
-      onCancel: () => {
-        close();
-      },
-    });
-  };
-
-  return { openConfirmModal, close };
-};
 
 export const QuizCreateInputList = ({
   register,

--- a/service/src/quiz/pages/QuizCreatePage/components/QuizCreateInputList/index.tsx
+++ b/service/src/quiz/pages/QuizCreatePage/components/QuizCreateInputList/index.tsx
@@ -30,10 +30,7 @@ export const QuizCreateInputList = ({
   isLoading,
 }: QuizCreateInputListProps) => {
   const uploadRef: ComponentProps<typeof Upload>['ref'] | null = useRef(null);
-  const { openConfirmModal } = useConfirmModal(() => {
-    uploadRef.current?.reset();
-    reset();
-  });
+  const { openConfirmModal } = useConfirmModal();
   return (
     <Flex
       direction="column"
@@ -79,8 +76,13 @@ export const QuizCreateInputList = ({
         <Button
           htmlType="reset"
           type="ghost"
-          onClick={() => {
-            openConfirmModal();
+          onClick={event => {
+            event.preventDefault();
+            openConfirmModal(() => {
+              ((event.target as Element).closest('form') as HTMLFormElement).reset();
+              uploadRef.current?.reset();
+              reset();
+            });
           }}
         >
           다시 만들기

--- a/service/src/quiz/pages/QuizCreatePage/hooks/useConfirmModal.tsx
+++ b/service/src/quiz/pages/QuizCreatePage/hooks/useConfirmModal.tsx
@@ -1,0 +1,35 @@
+import { Text, useModal } from '@depromeet/toks-components';
+import { Flex, Spacing } from '@toss/emotion-utils';
+
+export const useConfirmModal = (confirmCallback: () => void) => {
+  const { openModal, close } = useModal();
+  const openConfirmModal = async () => {
+    await openModal({
+      children: (
+        <Flex.Center direction="column">
+          <Text variant="title03" as="h3" css={{ margin: 0 }}>
+            작성 중인 퀴즈가 있어요.
+          </Text>
+          <Text variant="title03" as="h3" css={{ margin: 0 }}>
+            다시 만드시겠어요?
+          </Text>
+          <Text variant="body01" as="span" css={{ marginTop: '8px' }}>
+            다시 만들 경우, 지금까지 작성한 퀴즈 내용는 다시 복구할 수 없어요.
+          </Text>
+          <Spacing size={56} />
+        </Flex.Center>
+      ),
+      type: 'confirm',
+      buttonText: '다시 만들기',
+      onConfirm: () => {
+        confirmCallback();
+        close();
+      },
+      onCancel: () => {
+        close();
+      },
+    });
+  };
+
+  return { openConfirmModal, close };
+};

--- a/service/src/quiz/pages/QuizCreatePage/hooks/useConfirmModal.tsx
+++ b/service/src/quiz/pages/QuizCreatePage/hooks/useConfirmModal.tsx
@@ -1,9 +1,9 @@
 import { Text, useModal } from '@depromeet/toks-components';
 import { Flex, Spacing } from '@toss/emotion-utils';
 
-export const useConfirmModal = (confirmCallback: () => void) => {
+export const useConfirmModal = () => {
   const { openModal, close } = useModal();
-  const openConfirmModal = async () => {
+  const openConfirmModal = async (confirmCallback?: () => void) => {
     await openModal({
       children: (
         <Flex.Center direction="column">
@@ -22,7 +22,7 @@ export const useConfirmModal = (confirmCallback: () => void) => {
       type: 'confirm',
       buttonText: '다시 만들기',
       onConfirm: () => {
-        confirmCallback();
+        confirmCallback?.();
         close();
       },
       onCancel: () => {


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
- 다시 만들기 클릭시 확인 모달이 나오도록 구현하였습니다
- 모달 안에 들어가는 내용은 텍스트 뿐이라 따로 컴포넌트로 만들진 않았습니다
- 대신 openModal에 들어가는 내용이 커져서 따로 useConfirmModal로 컴포넌트 밖으로 로직을 뺐습니다
<img width="1435" alt="스크린샷 2023-03-15 오후 12 58 45" src="https://user-images.githubusercontent.com/47452547/225202765-f1bc9d9c-9233-4b41-a56d-1ba243bfb073.png">

## 💁 무엇이 어떻게 바뀌나요?
- 디자인 레퍼런스: 
- 관련 슬랙 링크: 

## 💬 리뷰어분들께 
<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!-- 
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->