### PR TITLE
fix(@depromeet/toks-components, quiz) : 퀴즈 아이템의 비활성 상태 버튼 클릭시 아코디언 접히는 문제 해결

### DIFF
--- a/service/src/quiz/pages/StudyDetailPage/components/QuizItem/index.tsx
+++ b/service/src/quiz/pages/StudyDetailPage/components/QuizItem/index.tsx
@@ -15,20 +15,6 @@ interface QuizItemProps {
   setQuizItemStatus: (quizId: number, newQuizStatus: QuizStatus) => QuizResponse | undefined;
 }
 
-// type QuizItemMap = {
-//   [key in QuizStatus]: {
-//     buttonColor: ComponentProps<typeof Button>['type'];
-//     timerColor: KeyOfColors;
-//     labelColor: string;
-//     backgroundColor: string;
-//     button: {
-//       string : {
-//         path:
-//       }
-//     }
-//   };
-// };
-
 const QUIZ_BUTTON_TYPE = {
   CHECK: {
     buttonName: '똑스 확인하기',
@@ -95,7 +81,6 @@ export function QuizItem({ round, quiz, setQuizItemStatus }: QuizItemProps) {
   const { time, start: timerStart, stop: timerStop } = useTimer({ time: initialTime, enabled: false });
 
   const [isFold, setIsFold] = useState(quizStatus === 'DONE');
-  const onFold = () => setIsFold(!isFold);
 
   const router = useRouter();
 
@@ -132,7 +117,12 @@ export function QuizItem({ round, quiz, setQuizItemStatus }: QuizItemProps) {
     <ListItem>
       <Accordion
         isFold={isFold}
-        onFold={onFold}
+        onFold={event => {
+          if ((event.target as Element).closest('button')) {
+            return;
+          }
+          setIsFold(!isFold);
+        }}
         accordionStyle={{
           padding: '22px 28px',
         }}
@@ -180,8 +170,7 @@ export function QuizItem({ round, quiz, setQuizItemStatus }: QuizItemProps) {
               width={140}
               disabled={quizStatus === 'TO_DO'}
               size="medium"
-              onClick={event => {
-                event.stopPropagation();
+              onClick={() => {
                 router.push(QUIZ_ITEM[quizStatus].button(quizSolveStep, myQuiz).path(quizId));
               }}
             >

--- a/shared/toks-components/src/components/Accordion/index.tsx
+++ b/shared/toks-components/src/components/Accordion/index.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { MouseEventHandler, ReactNode } from 'react';
 
 import { Icon } from '@depromeet/toks-components';
 
@@ -9,7 +9,7 @@ interface AccordionProps {
   bodyNodes: ReactNode;
   backgroundColor: string;
   isFold: boolean;
-  onFold?: () => void;
+  onFold?: MouseEventHandler<HTMLDivElement>;
   accordionStyle?: React.CSSProperties;
 }
 


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
- 퀴즈 아이템의 비활성 상태 버튼 클릭시 아코디언 접히는 문제를 해결했습니다. (민석님이 올려주신 QA)
- 아코디언의 onFold인자에 event매개변수를 받을 수 있도록 타입을 수정했습니다(MouseEventHandler<HTMLDivElement>)
- stopPropagation은 어차피 disabled된 버튼이라 적용할 수 없었고 가급적이면 버블링을 막지 않은게 좋겠다고 생각했습니다
- onFold 핸들러 함수 안에서 event.target과 closest를 활용하여 클릭된게 버튼인지 확인하고 얼리 리턴하여 해결했습니다

## 💁 무엇이 어떻게 바뀌나요?
- 디자인 레퍼런스: 
- 관련 슬랙 링크: https://5gaeanmal.slack.com/archives/C04HVDY7LFJ/p1678628030654779

## 💬 리뷰어분들께 
<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!-- 
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->