### PR TITLE
feat(Quiz): Quiz페이지 레이아웃 작업, Parallel Routes 활용

### DIFF
--- a/src/app/quiz/QuizCarousel.tsx
+++ b/src/app/quiz/QuizCarousel.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 function QuizCarousel() {
   return <div>Quiz Carousel</div>;
 }

--- a/src/app/quiz/QuizCarousel.tsx
+++ b/src/app/quiz/QuizCarousel.tsx
@@ -1,0 +1,5 @@
+function QuizCarousel() {
+  return <div>Quiz Carousel</div>;
+}
+
+export default QuizCarousel;

--- a/src/app/quiz/[quizId]/@comment/page.tsx
+++ b/src/app/quiz/[quizId]/@comment/page.tsx
@@ -1,0 +1,11 @@
+type Props = {
+  params: {
+    quizId: string;
+  };
+};
+
+function CommentPage({ params: { quizId } }: Props) {
+  return <div>Comment Page : {quizId}</div>;
+}
+
+export default CommentPage;

--- a/src/app/quiz/[quizId]/@detail/page.tsx
+++ b/src/app/quiz/[quizId]/@detail/page.tsx
@@ -1,0 +1,11 @@
+type Props = {
+  params: {
+    quizId: string;
+  };
+};
+
+function DetailPage({ params: { quizId } }: Props) {
+  return <div>Detail Page : {quizId}</div>;
+}
+
+export default DetailPage;

--- a/src/app/quiz/[quizId]/@detail/page.tsx
+++ b/src/app/quiz/[quizId]/@detail/page.tsx
@@ -4,8 +4,36 @@ type Props = {
   };
 };
 
-function DetailPage({ params: { quizId } }: Props) {
-  return <div>Detail Page : {quizId}</div>;
+// 임시 타입
+type QuizType = {
+  userId: string;
+  id: string;
+  title: string;
+  completed: boolean;
+};
+
+const getQuizDetail = async (quizId: string) => {
+  const result = await fetch(
+    // 테스트로 가져온 투두데이터
+    `https://jsonplaceholder.typicode.com/todos/${quizId}`
+  );
+  const todo: QuizType = await result.json();
+  return todo;
+};
+
+async function DetailPage({ params: { quizId } }: Props) {
+  const quizDetailData = await getQuizDetail(quizId);
+  return (
+    <div style={{ backgroundColor: '#d18760' }}>
+      <h1>퀴즈 디테일 영역 입니다.</h1>
+      <div>아이디 가져오기 가능 Quiz Id : {quizId}</div>
+      <div>Todo Title : {quizDetailData.title}</div>
+      <div>
+        Completed :
+        {quizDetailData.completed ? <span> Yes</span> : <span> No</span>}
+      </div>
+    </div>
+  );
 }
 
 export default DetailPage;

--- a/src/app/quiz/[quizId]/layout.tsx
+++ b/src/app/quiz/[quizId]/layout.tsx
@@ -1,0 +1,19 @@
+type Props = {
+  params: {
+    quizId: string;
+  };
+  detail: React.ReactNode;
+  comment: React.ReactNode;
+};
+
+function QuizIdLayout({ params: { quizId }, detail, comment }: Props) {
+  return (
+    <div>
+      <div>Quiz Id : {quizId}</div>
+      {detail}
+      {comment}
+    </div>
+  );
+}
+
+export default QuizIdLayout;

--- a/src/app/quiz/error.tsx
+++ b/src/app/quiz/error.tsx
@@ -1,0 +1,6 @@
+'use client';
+function Error() {
+  return <div>다시 조회해주세요.</div>;
+}
+
+export default Error;

--- a/src/app/quiz/layout.tsx
+++ b/src/app/quiz/layout.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import QuizCarousel from './QuizCarousel';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+function QuizLayout({ children }: Props) {
+  return (
+    <div>
+      <div>{children}</div>
+      <QuizCarousel />
+    </div>
+  );
+}
+
+export default QuizLayout;

--- a/src/app/quiz/page.tsx
+++ b/src/app/quiz/page.tsx
@@ -1,0 +1,5 @@
+function QuizPage() {
+  return <div>퀴즈의 ID로 조회해주세요.</div>;
+}
+
+export default QuizPage;


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
- 퀴즈 페이지 작업 전, 레이아웃 미리 만들겸 구조 공유 차 먼저 올렸습니다
- `/quiz/{quizId}`로 위치 정의 했습니다.
- 퀴즈 상세, 퀴즈 댓글은 Quiz Id에 따른 데이터 페칭을 예상해서 Parallel Routes로 컴포넌트를 가져왔습니다. (QuizIdLayout)
- 퀴즈 더보기 영역은 Quiz Id로 참조하는게 일단 아닐거라 예상하여 별도의 컴포넌트로 가져왔고 QuizLayout에서 가져오게 했습니다.
<img width="695" alt="스크린샷 2023-07-02 오후 7 57 26" src="https://github.com/depromeet/toks-web/assets/47452547/c6fed3ad-5738-44ca-ae8e-da24347fbd7d">

## 💁 무엇이 어떻게 바뀌나요?

- 디자인 레퍼런스:
- 관련 슬랙 링크:

## 💬 리뷰어분들께
https://nextjs.org/docs/app/building-your-application/routing/parallel-routes
더 해봐야 알거 같긴 한데 refetch에 따른 페이지 업데이트를 이런 라우팅으로 해결할 수 있을거 같아요..!
구조 관련해서 더 좋은 아이디어나 피드백 부탁드립니다!
<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->
