### PR TITLE
feat(quiz): 퀴즈 상세 영역 클라이언트 컴포넌트로 전환, 퀴즈 제출 기능 구현

### DIFF
--- a/src/app/quiz/[quizId]/@detail/page.tsx
+++ b/src/app/quiz/[quizId]/@detail/page.tsx
@@ -18,10 +18,12 @@ type Props = {
 
 function DetailPage({ params: { quizId } }: Props) {
   const { submitQuiz } = useSubmitQuizMutation(quizId);
-  const quizDetail = useGetQuizDetailQuery(quizId);
-  if (quizDetail === null) {
+  const { data: quizDetail } = useGetQuizDetailQuery(quizId);
+
+  if (quizDetail === undefined) {
     return null;
   }
+
   const {
     quizTitle,
     tags,

--- a/src/app/quiz/[quizId]/@detail/page.tsx
+++ b/src/app/quiz/[quizId]/@detail/page.tsx
@@ -33,7 +33,7 @@ async function DetailPage({ params: { quizId } }: Props) {
   const isExistOXImage = Boolean(oxImageUrl);
   const isVisibleOXImage = !isSubmitted && isExistOXImage;
   const replyAnswer = quizReply?.answer;
-  const isOXCorrectAnswer = replyAnswer === oxAnswer;
+  const isOXCorrectAnswer = replyAnswer === oxAnswer; // 퀴즈의 정답이 1혹은 2 사용자의 답안은 O혹은 X로 넘어오는 문제 해결 안된 상태
   const checkSameQuizType = (type: string) => quizType.startsWith(type);
   const checkSelectedAnswer = (buttonType: QuizButtonType) =>
     replyAnswer === buttonType;
@@ -93,14 +93,18 @@ async function DetailPage({ params: { quizId } }: Props) {
               />
             </>
           ) : isSubmitted ? (
-            <div className="flex flex-col items-center">
+            <div className="mx-auto flex flex-col items-center">
               <Thumbnail OXType={isOXCorrectAnswer ? 'O' : 'X'} />
               <Text className="mt-20px " typo="headingL" color="gray10">
                 {isOXCorrectAnswer
                   ? '딩동댕! 정답이에요.'
                   : '앗, 오답이에요! 정답은...'}
               </Text>
-              <Text className="mt-2px " typo="bodyBold" color="blue10">
+              <Text
+                className="mt-2px "
+                typo="bodyBold"
+                color={isOXCorrectAnswer ? 'blue10' : 'dangerDefault'}
+              >
                 {checkSelectedAnswer('O')
                   ? `${answerPercentage.left}% (${answerCount.left}명)`
                   : `${answerPercentage.right}% (${answerCount.right}명)`}

--- a/src/app/quiz/[quizId]/@detail/page.tsx
+++ b/src/app/quiz/[quizId]/@detail/page.tsx
@@ -14,21 +14,25 @@ type Props = {
 };
 
 function DetailPage({ params: { quizId } }: Props) {
+  const quizDetail = useGetQuizDetailQuery(quizId);
+  if (quizDetail === null) {
+    return null;
+  }
   const {
     quizTitle,
     tags,
     oxImageUrl,
-    button1,
-    button2,
+    buttonLeft,
+    buttonRight,
     quizType,
     oxDescription,
     oxAnswer,
     categoryName,
     quizReply,
-    totalCount,
-    replyCount,
+    answerPercentage,
+    answerParticipationLabel,
     isSubmitted,
-  } = useGetQuizDetailQuery(quizId);
+  } = quizDetail;
 
   const isExistOXImage = Boolean(oxImageUrl);
   const isVisibleOXImage = !isSubmitted && isExistOXImage;
@@ -37,21 +41,6 @@ function DetailPage({ params: { quizId } }: Props) {
   const checkSameQuizType = (type: string) => quizType.startsWith(type);
   const checkSelectedAnswer = (buttonType: QuizButtonType) =>
     replyAnswer === buttonType;
-
-  const answerCount = {
-    left: replyCount?.A?.count ?? replyCount?.O?.count ?? 0,
-    right: replyCount?.B?.count ?? replyCount?.X?.count ?? 0,
-  };
-
-  const answerPercentage = {
-    left: Math.floor((answerCount.left / totalCount) * 100),
-    right: Math.floor((answerCount.right / totalCount) * 100),
-  };
-
-  const answerParticipationLabel = {
-    left: `${answerPercentage.left}% (${answerCount.left}명)`,
-    right: `${answerPercentage.right}% (${answerCount.right}명)`,
-  };
 
   const handleSubmitQuiz = async (answer: QuizButtonType) => {
     // try {
@@ -91,20 +80,20 @@ function DetailPage({ params: { quizId } }: Props) {
             <>
               <QuizButton
                 isSubmitted={isSubmitted}
-                imageUrl={button1.imageUrl}
+                imageUrl={buttonLeft.imageUrl}
                 percentage={answerPercentage.left}
                 participationLabel={answerParticipationLabel.left}
                 isSelected={checkSelectedAnswer('A')}
-                name={button1.button.name}
+                name={buttonLeft.button.name}
                 onClick={() => handleSubmitQuiz('A')}
               />
               <QuizButton
                 isSubmitted={isSubmitted}
-                imageUrl={button2.imageUrl}
+                imageUrl={buttonRight.imageUrl}
                 percentage={answerPercentage.right}
                 participationLabel={answerParticipationLabel.right}
                 isSelected={checkSelectedAnswer('B')}
-                name={button2.button.name}
+                name={buttonRight.button.name}
                 onClick={() => handleSubmitQuiz('B')}
               />
             </>

--- a/src/app/quiz/[quizId]/@detail/page.tsx
+++ b/src/app/quiz/[quizId]/@detail/page.tsx
@@ -13,7 +13,7 @@ type Props = {
 async function DetailPage({ params: { quizId } }: Props) {
   const {
     quiz: {
-      title,
+      title: quizTitle,
       tags,
       question: {
         imageUrl: oxImageUrl,
@@ -24,6 +24,10 @@ async function DetailPage({ params: { quizId } }: Props) {
     category: { name: categoryName },
     isSubmitted,
   } = await getQuizDetailByQuizId(quizId);
+
+  const isQuizType = (type: string) => quizType.startsWith(type);
+  const isExistOXImage = Boolean(oxImageUrl);
+  const isVisibleOXImage = !isSubmitted && isExistOXImage;
 
   return (
     <section className={clsx(bgColor['gray110'], 'mt-8px rounded-16px p-20px')}>
@@ -39,10 +43,10 @@ async function DetailPage({ params: { quizId } }: Props) {
         ))}
       </div>
       <Text className="mt-12px block " typo="headingL" color="gray10">
-        {title}
+        {quizTitle}
       </Text>
       <div className="mt-48px">
-        {!isSubmitted && oxImageUrl && (
+        {isVisibleOXImage && (
           <Thumbnail
             className="mb-24px w-full"
             imageUrl={oxImageUrl}
@@ -50,7 +54,7 @@ async function DetailPage({ params: { quizId } }: Props) {
           />
         )}
         <div className="flex gap-16px">
-          {quizType.startsWith('A_B_') ? (
+          {isQuizType('A_B_') ? (
             <>
               <QuizButton
                 isSubmitted={isSubmitted}
@@ -88,12 +92,12 @@ async function DetailPage({ params: { quizId } }: Props) {
             <>
               <QuizButton
                 isSubmitted={isSubmitted}
-                OXType={quizType === 'O_X_IMAGE' ? undefined : 'O'}
+                OXType={isExistOXImage ? undefined : 'O'}
                 name="예"
               />
               <QuizButton
                 isSubmitted={isSubmitted}
-                OXType={quizType === 'O_X_IMAGE' ? undefined : 'X'}
+                OXType={isExistOXImage ? undefined : 'X'}
                 name="아니오"
               />
             </>

--- a/src/app/quiz/[quizId]/@detail/page.tsx
+++ b/src/app/quiz/[quizId]/@detail/page.tsx
@@ -17,7 +17,7 @@ type Props = {
   };
 };
 
-async function DetailPage({ params: { quizId } }: Props) {
+function DetailPage({ params: { quizId } }: Props) {
   const router = useRouter();
 
   const {

--- a/src/app/quiz/[quizId]/@detail/page.tsx
+++ b/src/app/quiz/[quizId]/@detail/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import clsx from 'clsx';
 import { useRouter } from 'next/navigation';
 
@@ -59,13 +61,13 @@ async function DetailPage({ params: { quizId } }: Props) {
     right: `${answerPercentage.right}% (${answerCount.right}명)`,
   };
 
-  // const handleSubmitQuiz = async (answer: QuizButtonType) => {
-  //   try {
-  //     await postSubmitQuizByQuizId(quizId, answer);
-  //   } finally {
-  //     router.refresh();
-  //   }
-  // };
+  const handleSubmitQuiz = async (answer: QuizButtonType) => {
+    try {
+      await postSubmitQuizByQuizId(quizId, answer);
+    } finally {
+      router.refresh();
+    }
+  };
 
   return (
     <section className={clsx(bgColor['gray110'], 'mt-8px rounded-16px p-20px')}>

--- a/src/app/quiz/[quizId]/@detail/page.tsx
+++ b/src/app/quiz/[quizId]/@detail/page.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 
 import { QuizButton, Thumbnail } from '@/app/quiz/components';
+import { QuizButtonType } from '@/app/quiz/models/quiz';
 import { getQuizDetailByQuizId } from '@/app/quiz/remotes/quiz';
 import { Text, bgColor } from '@/common';
 
@@ -22,12 +23,27 @@ async function DetailPage({ params: { quizId } }: Props) {
       quizType,
     },
     category: { name: categoryName },
+    quizReply,
+    quizReplyCount: { totalCount, replyCount },
     isSubmitted,
   } = await getQuizDetailByQuizId(quizId);
 
-  const isQuizType = (type: string) => quizType.startsWith(type);
   const isExistOXImage = Boolean(oxImageUrl);
   const isVisibleOXImage = !isSubmitted && isExistOXImage;
+  const replyAnswer = quizReply?.answer;
+  const checkSameQuizType = (type: string) => quizType.startsWith(type);
+  const checkSelectedAnswer = (buttonType: QuizButtonType) =>
+    replyAnswer === buttonType;
+
+  const answerCount = {
+    left: replyCount?.A?.count ?? replyCount?.O?.count ?? 0,
+    right: replyCount?.B?.count ?? replyCount?.X?.count ?? 0,
+  };
+
+  const answerPercentage = {
+    left: Math.floor((answerCount.left / totalCount) * 100),
+    right: Math.floor((answerCount.right / totalCount) * 100),
+  };
 
   return (
     <section className={clsx(bgColor['gray110'], 'mt-8px rounded-16px p-20px')}>
@@ -54,28 +70,28 @@ async function DetailPage({ params: { quizId } }: Props) {
           />
         )}
         <div className="flex gap-16px">
-          {isQuizType('A_B_') ? (
+          {checkSameQuizType('A_B_') ? (
             <>
               <QuizButton
                 isSubmitted={isSubmitted}
                 imageUrl={button1.imageUrl}
-                percentage={55}
-                participationLabel="60% (600명)"
-                isSelected={true}
+                percentage={answerPercentage.left}
+                participationLabel={`${answerPercentage.left}% (${answerCount.left}명)`}
+                isSelected={checkSelectedAnswer('A')}
                 name={button1.button.name}
               />
               <QuizButton
                 isSubmitted={isSubmitted}
                 imageUrl={button2.imageUrl}
-                percentage={45}
-                participationLabel="40% (400명)"
-                isSelected={false}
+                percentage={answerPercentage.right}
+                participationLabel={`${answerPercentage.right}% (${answerCount.right}명)`}
+                isSelected={checkSelectedAnswer('B')}
                 name={button2.button.name}
               />
             </>
           ) : isSubmitted ? (
             <div className="flex flex-col items-center">
-              <Thumbnail OXType="O" />
+              <Thumbnail OXType={replyAnswer as 'O' | 'X'} />
               <Text className="mt-20px " typo="headingL" color="gray10">
                 딩동댕! 정답이에요.
               </Text>

--- a/src/app/quiz/[quizId]/@detail/page.tsx
+++ b/src/app/quiz/[quizId]/@detail/page.tsx
@@ -3,7 +3,10 @@
 import clsx from 'clsx';
 
 import { QuizButton, Thumbnail } from '@/app/quiz/components';
-import { useGetQuizDetailQuery } from '@/app/quiz/hooks/useGetQuizDetailQuery';
+import {
+  useGetQuizDetailQuery,
+  useSubmitQuizMutation,
+} from '@/app/quiz/hooks/';
 import { QuizButtonType } from '@/app/quiz/models/quiz';
 import { Text, bgColor } from '@/common';
 
@@ -14,6 +17,7 @@ type Props = {
 };
 
 function DetailPage({ params: { quizId } }: Props) {
+  const { submitQuiz } = useSubmitQuizMutation(quizId);
   const quizDetail = useGetQuizDetailQuery(quizId);
   if (quizDetail === null) {
     return null;
@@ -41,15 +45,6 @@ function DetailPage({ params: { quizId } }: Props) {
   const checkSameQuizType = (type: string) => quizType.startsWith(type);
   const checkSelectedAnswer = (buttonType: QuizButtonType) =>
     replyAnswer === buttonType;
-
-  const handleSubmitQuiz = async (answer: QuizButtonType) => {
-    // try {
-    //   await postSubmitQuizByQuizId(quizId, answer);
-    // } finally {
-    //   router.refresh();
-    // }
-    answer;
-  };
 
   return (
     <section className={clsx(bgColor['gray110'], 'mt-8px rounded-16px p-20px')}>
@@ -85,7 +80,7 @@ function DetailPage({ params: { quizId } }: Props) {
                 participationLabel={answerParticipationLabel.left}
                 isSelected={checkSelectedAnswer('A')}
                 name={buttonLeft.button.name}
-                onClick={() => handleSubmitQuiz('A')}
+                onClick={() => submitQuiz('A')}
               />
               <QuizButton
                 isSubmitted={isSubmitted}
@@ -94,7 +89,7 @@ function DetailPage({ params: { quizId } }: Props) {
                 participationLabel={answerParticipationLabel.right}
                 isSelected={checkSelectedAnswer('B')}
                 name={buttonRight.button.name}
-                onClick={() => handleSubmitQuiz('B')}
+                onClick={() => submitQuiz('B')}
               />
             </>
           ) : isSubmitted ? (
@@ -124,13 +119,13 @@ function DetailPage({ params: { quizId } }: Props) {
                 isSubmitted={isSubmitted}
                 OXType={isExistOXImage ? undefined : 'O'}
                 name="예"
-                onClick={() => handleSubmitQuiz('O')}
+                onClick={() => submitQuiz('O')}
               />
               <QuizButton
                 isSubmitted={isSubmitted}
                 OXType={isExistOXImage ? undefined : 'X'}
                 name="아니오"
-                onClick={() => handleSubmitQuiz('X')}
+                onClick={() => submitQuiz('X')}
               />
             </>
           )}

--- a/src/app/quiz/[quizId]/@detail/page.tsx
+++ b/src/app/quiz/[quizId]/@detail/page.tsx
@@ -1,14 +1,10 @@
 'use client';
 
 import clsx from 'clsx';
-import { useRouter } from 'next/navigation';
 
 import { QuizButton, Thumbnail } from '@/app/quiz/components';
+import { useGetQuizDetailQuery } from '@/app/quiz/hooks/useGetQuizDetailQuery';
 import { QuizButtonType } from '@/app/quiz/models/quiz';
-import {
-  getQuizDetailByQuizId,
-  postSubmitQuizByQuizId,
-} from '@/app/quiz/remotes/quiz';
 import { Text, bgColor } from '@/common';
 
 type Props = {
@@ -18,25 +14,21 @@ type Props = {
 };
 
 function DetailPage({ params: { quizId } }: Props) {
-  const router = useRouter();
-
   const {
-    quiz: {
-      title: quizTitle,
-      tags,
-      question: {
-        imageUrl: oxImageUrl,
-        buttons: { '1': button1, '2': button2 },
-      },
-      quizType,
-      description: oxDescription,
-      answer: oxAnswer,
-    },
-    category: { name: categoryName },
+    quizTitle,
+    tags,
+    oxImageUrl,
+    button1,
+    button2,
+    quizType,
+    oxDescription,
+    oxAnswer,
+    categoryName,
     quizReply,
-    quizReplyCount: { totalCount, replyCount },
+    totalCount,
+    replyCount,
     isSubmitted,
-  } = await getQuizDetailByQuizId(quizId);
+  } = useGetQuizDetailQuery(quizId);
 
   const isExistOXImage = Boolean(oxImageUrl);
   const isVisibleOXImage = !isSubmitted && isExistOXImage;
@@ -62,11 +54,12 @@ function DetailPage({ params: { quizId } }: Props) {
   };
 
   const handleSubmitQuiz = async (answer: QuizButtonType) => {
-    try {
-      await postSubmitQuizByQuizId(quizId, answer);
-    } finally {
-      router.refresh();
-    }
+    // try {
+    //   await postSubmitQuizByQuizId(quizId, answer);
+    // } finally {
+    //   router.refresh();
+    // }
+    answer;
   };
 
   return (

--- a/src/app/quiz/[quizId]/@detail/page.tsx
+++ b/src/app/quiz/[quizId]/@detail/page.tsx
@@ -21,6 +21,8 @@ async function DetailPage({ params: { quizId } }: Props) {
         buttons: { '1': button1, '2': button2 },
       },
       quizType,
+      description: oxDescription,
+      answer: oxAnswer,
     },
     category: { name: categoryName },
     quizReply,
@@ -31,6 +33,7 @@ async function DetailPage({ params: { quizId } }: Props) {
   const isExistOXImage = Boolean(oxImageUrl);
   const isVisibleOXImage = !isSubmitted && isExistOXImage;
   const replyAnswer = quizReply?.answer;
+  const isOXCorrectAnswer = replyAnswer === oxAnswer;
   const checkSameQuizType = (type: string) => quizType.startsWith(type);
   const checkSelectedAnswer = (buttonType: QuizButtonType) =>
     replyAnswer === buttonType;
@@ -91,17 +94,19 @@ async function DetailPage({ params: { quizId } }: Props) {
             </>
           ) : isSubmitted ? (
             <div className="flex flex-col items-center">
-              <Thumbnail OXType={replyAnswer as 'O' | 'X'} />
+              <Thumbnail OXType={isOXCorrectAnswer ? 'O' : 'X'} />
               <Text className="mt-20px " typo="headingL" color="gray10">
-                딩동댕! 정답이에요.
+                {isOXCorrectAnswer
+                  ? '딩동댕! 정답이에요.'
+                  : '앗, 오답이에요! 정답은...'}
               </Text>
               <Text className="mt-2px " typo="bodyBold" color="blue10">
-                60% (600명)
+                {checkSelectedAnswer('O')
+                  ? `${answerPercentage.left}% (${answerCount.left}명)`
+                  : `${answerPercentage.right}% (${answerCount.right}명)`}
               </Text>
               <Text className="mt-24px block" typo="body" color="white">
-                익숙한 경험에 따 작동되도록 기대하는 심리학 이론은 ‘제이콤의
-                법칙'이 많아요 어저고 저쩌고 어저고 저쩌고어저고 저쩌고어저고
-                저쩌고
+                {oxDescription}
               </Text>
             </div>
           ) : (

--- a/src/app/quiz/[quizId]/@detail/page.tsx
+++ b/src/app/quiz/[quizId]/@detail/page.tsx
@@ -1,8 +1,12 @@
 import clsx from 'clsx';
+import { useRouter } from 'next/navigation';
 
 import { QuizButton, Thumbnail } from '@/app/quiz/components';
 import { QuizButtonType } from '@/app/quiz/models/quiz';
-import { getQuizDetailByQuizId } from '@/app/quiz/remotes/quiz';
+import {
+  getQuizDetailByQuizId,
+  postSubmitQuizByQuizId,
+} from '@/app/quiz/remotes/quiz';
 import { Text, bgColor } from '@/common';
 
 type Props = {
@@ -12,6 +16,8 @@ type Props = {
 };
 
 async function DetailPage({ params: { quizId } }: Props) {
+  const router = useRouter();
+
   const {
     quiz: {
       title: quizTitle,
@@ -48,6 +54,19 @@ async function DetailPage({ params: { quizId } }: Props) {
     right: Math.floor((answerCount.right / totalCount) * 100),
   };
 
+  const answerParticipationLabel = {
+    left: `${answerPercentage.left}% (${answerCount.left}명)`,
+    right: `${answerPercentage.right}% (${answerCount.right}명)`,
+  };
+
+  // const handleSubmitQuiz = async (answer: QuizButtonType) => {
+  //   try {
+  //     await postSubmitQuizByQuizId(quizId, answer);
+  //   } finally {
+  //     router.refresh();
+  //   }
+  // };
+
   return (
     <section className={clsx(bgColor['gray110'], 'mt-8px rounded-16px p-20px')}>
       <div className="flex gap-8px">
@@ -79,17 +98,19 @@ async function DetailPage({ params: { quizId } }: Props) {
                 isSubmitted={isSubmitted}
                 imageUrl={button1.imageUrl}
                 percentage={answerPercentage.left}
-                participationLabel={`${answerPercentage.left}% (${answerCount.left}명)`}
+                participationLabel={answerParticipationLabel.left}
                 isSelected={checkSelectedAnswer('A')}
                 name={button1.button.name}
+                onClick={() => handleSubmitQuiz('A')}
               />
               <QuizButton
                 isSubmitted={isSubmitted}
                 imageUrl={button2.imageUrl}
                 percentage={answerPercentage.right}
-                participationLabel={`${answerPercentage.right}% (${answerCount.right}명)`}
+                participationLabel={answerParticipationLabel.right}
                 isSelected={checkSelectedAnswer('B')}
                 name={button2.button.name}
+                onClick={() => handleSubmitQuiz('B')}
               />
             </>
           ) : isSubmitted ? (
@@ -106,8 +127,8 @@ async function DetailPage({ params: { quizId } }: Props) {
                 color={isOXCorrectAnswer ? 'blue10' : 'dangerDefault'}
               >
                 {checkSelectedAnswer('O')
-                  ? `${answerPercentage.left}% (${answerCount.left}명)`
-                  : `${answerPercentage.right}% (${answerCount.right}명)`}
+                  ? answerParticipationLabel.left
+                  : answerParticipationLabel.right}
               </Text>
               <Text className="mt-24px block" typo="body" color="white">
                 {oxDescription}
@@ -119,11 +140,13 @@ async function DetailPage({ params: { quizId } }: Props) {
                 isSubmitted={isSubmitted}
                 OXType={isExistOXImage ? undefined : 'O'}
                 name="예"
+                onClick={() => handleSubmitQuiz('O')}
               />
               <QuizButton
                 isSubmitted={isSubmitted}
                 OXType={isExistOXImage ? undefined : 'X'}
                 name="아니오"
+                onClick={() => handleSubmitQuiz('X')}
               />
             </>
           )}

--- a/src/app/quiz/[quizId]/@recommendation/page.tsx
+++ b/src/app/quiz/[quizId]/@recommendation/page.tsx
@@ -1,5 +1,5 @@
 import { QuizCarousel } from '@/app/quiz/components';
-import { getRecommendationByQuizId } from '@/app/quiz/remotes/quiz';
+import { getRecommendationByQuizId } from '@/app/quiz/remotes/recommendation';
 import { Text } from '@/common';
 
 type Props = {

--- a/src/app/quiz/[quizId]/layout.tsx
+++ b/src/app/quiz/[quizId]/layout.tsx
@@ -8,14 +8,14 @@ type Props = {
 
 function QuizIdLayout({ detail, comment, recommendation }: Props) {
   return (
-    <div className="pb-80px">
+    <main className="pb-80px">
       <QuizProvider>
         {detail}
         {comment}
         {recommendation}
         <ScrollToTopButton />
       </QuizProvider>
-    </div>
+    </main>
   );
 }
 

--- a/src/app/quiz/components/QuizButton/index.tsx
+++ b/src/app/quiz/components/QuizButton/index.tsx
@@ -18,9 +18,14 @@ export function QuizButton({
   participationLabel,
   className,
   name,
+  ...rest
 }: QuizButtonProps) {
   return (
-    <button className={clsx(className, 'flex flex-1 flex-col items-center')}>
+    <button
+      className={clsx(className, 'flex flex-1 flex-col items-center')}
+      disabled={isSubmitted}
+      {...rest}
+    >
       {(OXType || imageUrl) && (
         <Thumbnail
           className="mb-24px w-full"

--- a/src/app/quiz/components/QuizButton/type.ts
+++ b/src/app/quiz/components/QuizButton/type.ts
@@ -10,5 +10,4 @@ export interface QuizButtonProps
   participationLabel?: string;
   className?: string;
   name: string;
-  handleSubmitQuiz: () => void;
 }

--- a/src/app/quiz/components/QuizButton/type.ts
+++ b/src/app/quiz/components/QuizButton/type.ts
@@ -10,4 +10,5 @@ export interface QuizButtonProps
   participationLabel?: string;
   className?: string;
   name: string;
+  handleSubmitQuiz: () => void;
 }

--- a/src/app/quiz/components/QuizButton/type.ts
+++ b/src/app/quiz/components/QuizButton/type.ts
@@ -1,8 +1,10 @@
+import { OX } from '@/app/quiz/models/quiz';
+
 export interface QuizButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   isSubmitted: boolean;
   isSelected?: boolean;
-  OXType?: 'O' | 'X';
+  OXType?: OX;
   imageUrl?: string;
   percentage?: number;
   participationLabel?: string;

--- a/src/app/quiz/components/QuizCarousel/index.tsx
+++ b/src/app/quiz/components/QuizCarousel/index.tsx
@@ -22,7 +22,7 @@ export function QuizCarousel({
       quizId: quiz.id,
       tags: quiz.tags,
       quizDescription: quiz.title,
-      image: quiz.question.buttons['1'].imageUrl,
+      image: quiz.question.buttons?.A?.imageUrl ?? quiz.question?.imageUrl,
       quizReplyHistoryCount,
       quizCommentCount,
       quizType: quiz.quizType,

--- a/src/app/quiz/constants/queryKeys.ts
+++ b/src/app/quiz/constants/queryKeys.ts
@@ -1,0 +1,3 @@
+export const QUERY_KEYS = {
+  GET_QUIZ_DETAIL: (quizId: string) => ['GET_QUIZ_DETAIL', quizId],
+} as const;

--- a/src/app/quiz/hooks/index.ts
+++ b/src/app/quiz/hooks/index.ts
@@ -1,0 +1,3 @@
+export * from './useCommentListRef';
+export * from './useGetQuizDetailQuery';
+export * from './useSubmitQuizMutation';

--- a/src/app/quiz/hooks/useGetQuizDetailQuery.ts
+++ b/src/app/quiz/hooks/useGetQuizDetailQuery.ts
@@ -3,69 +3,67 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { QUERY_KEYS } from '@/app/quiz/constants/queryKeys';
-import { QuizResponse } from '@/app/quiz/models/quiz';
 import { getQuizDetailByQuizId } from '@/app/quiz/remotes/quiz';
 
 export const useGetQuizDetailQuery = (quizId: string) => {
-  const { data: quizDetail, isError } = useQuery<QuizResponse>(
+  return useQuery(
     QUERY_KEYS.GET_QUIZ_DETAIL(quizId),
-    () => getQuizDetailByQuizId(quizId)
-  );
-
-  if (isError) {
-    throw new Error('퀴즈 상세 데이터를 가져오는데 실패했습니다.');
-  }
-
-  if (quizDetail === undefined) {
-    return null;
-  }
-
-  const {
-    quiz: {
-      title: quizTitle,
-      tags,
-      question: { imageUrl: oxImageUrl, buttons },
-      quizType,
-      description: oxDescription,
-      answer: oxAnswer,
+    async () => {
+      try {
+        return await getQuizDetailByQuizId(quizId);
+      } catch {
+        throw new Error('퀴즈 상세 데이터를 가져오는데 실패했습니다.');
+      }
     },
-    category: { name: categoryName },
-    quizReply,
-    quizReplyCount: { totalCount, replyCount },
-    isSubmitted,
-  } = quizDetail;
+    {
+      select: ({
+        quiz: {
+          title: quizTitle,
+          tags,
+          question: { imageUrl: oxImageUrl, buttons },
+          quizType,
+          description: oxDescription,
+          answer: oxAnswer,
+        },
+        category: { name: categoryName },
+        quizReply,
+        quizReplyCount: { totalCount, replyCount },
+        isSubmitted,
+      }) => {
+        const buttonLeft = buttons.A ?? buttons.O;
+        const buttonRight = buttons.B ?? buttons.X;
 
-  const buttonLeft = buttons.A ?? buttons.O;
-  const buttonRight = buttons.B ?? buttons.X;
+        const answerCount = {
+          left: replyCount?.A?.count ?? replyCount?.O?.count ?? 0,
+          right: replyCount?.B?.count ?? replyCount?.X?.count ?? 0,
+        };
 
-  const answerCount = {
-    left: replyCount?.A?.count ?? replyCount?.O?.count ?? 0,
-    right: replyCount?.B?.count ?? replyCount?.X?.count ?? 0,
-  };
+        const answerPercentage = {
+          left: Math.floor((answerCount.left / totalCount) * 100),
+          right: Math.floor((answerCount.right / totalCount) * 100),
+        };
 
-  const answerPercentage = {
-    left: Math.floor((answerCount.left / totalCount) * 100),
-    right: Math.floor((answerCount.right / totalCount) * 100),
-  };
+        const answerParticipationLabel = {
+          left: `${answerPercentage.left}% (${answerCount.left}명)`,
+          right: `${answerPercentage.right}% (${answerCount.right}명)`,
+        };
 
-  const answerParticipationLabel = {
-    left: `${answerPercentage.left}% (${answerCount.left}명)`,
-    right: `${answerPercentage.right}% (${answerCount.right}명)`,
-  };
-
-  return {
-    quizTitle,
-    tags,
-    oxImageUrl,
-    buttonLeft,
-    buttonRight,
-    quizType,
-    oxDescription,
-    oxAnswer,
-    categoryName,
-    quizReply,
-    answerPercentage,
-    answerParticipationLabel,
-    isSubmitted,
-  };
+        return {
+          quizTitle,
+          tags,
+          oxImageUrl,
+          buttonLeft,
+          buttonRight,
+          quizType,
+          oxDescription,
+          oxAnswer,
+          categoryName,
+          quizReply,
+          answerPercentage,
+          answerParticipationLabel,
+          isSubmitted,
+        };
+      },
+    }
+  );
 };

--- a/src/app/quiz/hooks/useGetQuizDetailQuery.ts
+++ b/src/app/quiz/hooks/useGetQuizDetailQuery.ts
@@ -1,0 +1,13 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { QUERY_KEYS } from '@/app/quiz/constants/queryKeys';
+import { QuizDetailResponse } from '@/app/quiz/models/quiz';
+import { getQuizDetailByQuizId } from '@/app/quiz/remotes/quiz';
+
+export const useGetQuizDetailQuery = (quizId: string) => {
+  return useQuery<QuizDetailResponse>(QUERY_KEYS.GET_QUIZ_DETAIL(quizId), () =>
+    getQuizDetailByQuizId(quizId)
+  );
+};

--- a/src/app/quiz/hooks/useGetQuizDetailQuery.ts
+++ b/src/app/quiz/hooks/useGetQuizDetailQuery.ts
@@ -7,7 +7,46 @@ import { QuizResponse } from '@/app/quiz/models/quiz';
 import { getQuizDetailByQuizId } from '@/app/quiz/remotes/quiz';
 
 export const useGetQuizDetailQuery = (quizId: string) => {
-  return useQuery<QuizResponse>(QUERY_KEYS.GET_QUIZ_DETAIL(quizId), () =>
-    getQuizDetailByQuizId(quizId)
+  const { data: quizDetail, isError } = useQuery<QuizResponse>(
+    QUERY_KEYS.GET_QUIZ_DETAIL(quizId),
+    () => getQuizDetailByQuizId(quizId)
   );
+
+  if (isError || quizDetail === undefined) {
+    throw new Error('퀴즈 상세 데이터를 가져오는데에 실패헀습니다.');
+  }
+
+  const {
+    quiz: {
+      title: quizTitle,
+      tags,
+      question: {
+        imageUrl: oxImageUrl,
+        buttons: { '1': button1, '2': button2 },
+      },
+      quizType,
+      description: oxDescription,
+      answer: oxAnswer,
+    },
+    category: { name: categoryName },
+    quizReply,
+    quizReplyCount: { totalCount, replyCount },
+    isSubmitted,
+  } = quizDetail;
+
+  return {
+    quizTitle,
+    tags,
+    oxImageUrl,
+    button1,
+    button2,
+    quizType,
+    oxDescription,
+    oxAnswer,
+    categoryName,
+    quizReply,
+    totalCount,
+    replyCount,
+    isSubmitted,
+  };
 };

--- a/src/app/quiz/hooks/useGetQuizDetailQuery.ts
+++ b/src/app/quiz/hooks/useGetQuizDetailQuery.ts
@@ -12,18 +12,19 @@ export const useGetQuizDetailQuery = (quizId: string) => {
     () => getQuizDetailByQuizId(quizId)
   );
 
-  if (isError || quizDetail === undefined) {
-    throw new Error('퀴즈 상세 데이터를 가져오는데에 실패헀습니다.');
+  if (isError) {
+    throw new Error('퀴즈 상세 데이터를 가져오는데 실패했습니다.');
+  }
+
+  if (quizDetail === undefined) {
+    return null;
   }
 
   const {
     quiz: {
       title: quizTitle,
       tags,
-      question: {
-        imageUrl: oxImageUrl,
-        buttons: { '1': button1, '2': button2 },
-      },
+      question: { imageUrl: oxImageUrl, buttons },
       quizType,
       description: oxDescription,
       answer: oxAnswer,
@@ -34,19 +35,37 @@ export const useGetQuizDetailQuery = (quizId: string) => {
     isSubmitted,
   } = quizDetail;
 
+  const buttonLeft = buttons.A ?? buttons.O;
+  const buttonRight = buttons.B ?? buttons.X;
+
+  const answerCount = {
+    left: replyCount?.A?.count ?? replyCount?.O?.count ?? 0,
+    right: replyCount?.B?.count ?? replyCount?.X?.count ?? 0,
+  };
+
+  const answerPercentage = {
+    left: Math.floor((answerCount.left / totalCount) * 100),
+    right: Math.floor((answerCount.right / totalCount) * 100),
+  };
+
+  const answerParticipationLabel = {
+    left: `${answerPercentage.left}% (${answerCount.left}명)`,
+    right: `${answerPercentage.right}% (${answerCount.right}명)`,
+  };
+
   return {
     quizTitle,
     tags,
     oxImageUrl,
-    button1,
-    button2,
+    buttonLeft,
+    buttonRight,
     quizType,
     oxDescription,
     oxAnswer,
     categoryName,
     quizReply,
-    totalCount,
-    replyCount,
+    answerPercentage,
+    answerParticipationLabel,
     isSubmitted,
   };
 };

--- a/src/app/quiz/hooks/useGetQuizDetailQuery.ts
+++ b/src/app/quiz/hooks/useGetQuizDetailQuery.ts
@@ -3,11 +3,11 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { QUERY_KEYS } from '@/app/quiz/constants/queryKeys';
-import { QuizDetailResponse } from '@/app/quiz/models/quiz';
+import { QuizResponse } from '@/app/quiz/models/quiz';
 import { getQuizDetailByQuizId } from '@/app/quiz/remotes/quiz';
 
 export const useGetQuizDetailQuery = (quizId: string) => {
-  return useQuery<QuizDetailResponse>(QUERY_KEYS.GET_QUIZ_DETAIL(quizId), () =>
+  return useQuery<QuizResponse>(QUERY_KEYS.GET_QUIZ_DETAIL(quizId), () =>
     getQuizDetailByQuizId(quizId)
   );
 };

--- a/src/app/quiz/hooks/useSubmitQuizMutaion.ts
+++ b/src/app/quiz/hooks/useSubmitQuizMutaion.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+import { QuizButtonType } from '@/app/quiz/models/quiz';
+import { postSubmitQuizByQuizId } from '@/app/quiz/remotes/quiz';
+
+export const useSubmitQuizMutaion = (
+  quizId: string,
+  answer: QuizButtonType
+) => {
+  const router = useRouter();
+  const { mutate: submitQuiz, isLoading } = useMutation(async () => {
+    try {
+      await postSubmitQuizByQuizId(quizId, answer);
+    } finally {
+      router.refresh();
+    }
+  });
+
+  return {
+    submitQuiz,
+    isLoading,
+  };
+};

--- a/src/app/quiz/hooks/useSubmitQuizMutaion.ts
+++ b/src/app/quiz/hooks/useSubmitQuizMutaion.ts
@@ -3,21 +3,20 @@
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 
-import { QuizButtonType } from '@/app/quiz/models/quiz';
+import { QuizSubmitRequest } from '@/app/quiz/models/quiz';
 import { postSubmitQuizByQuizId } from '@/app/quiz/remotes/quiz';
 
-export const useSubmitQuizMutaion = (
-  quizId: string,
-  answer: QuizButtonType
-) => {
+export const useSubmitQuizMutaion = () => {
   const router = useRouter();
-  const { mutate: submitQuiz, isLoading } = useMutation(async () => {
-    try {
-      await postSubmitQuizByQuizId(quizId, answer);
-    } finally {
-      router.refresh();
+  const { mutate: submitQuiz, isLoading } = useMutation(
+    async (values: QuizSubmitRequest) => {
+      try {
+        await postSubmitQuizByQuizId(values);
+      } finally {
+        router.refresh();
+      }
     }
-  });
+  );
 
   return {
     submitQuiz,

--- a/src/app/quiz/hooks/useSubmitQuizMutaion.ts
+++ b/src/app/quiz/hooks/useSubmitQuizMutaion.ts
@@ -1,20 +1,28 @@
 'use client';
 
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 
-import { QuizSubmitRequest } from '@/app/quiz/models/quiz';
+import { QUERY_KEYS } from '@/app/quiz/constants/queryKeys';
+import { QuizButtonType } from '@/app/quiz/models/quiz';
 import { postSubmitQuizByQuizId } from '@/app/quiz/remotes/quiz';
 
-export const useSubmitQuizMutaion = () => {
+export const useSubmitQuizMutaion = (quizId: string) => {
   const router = useRouter();
+  const queryClient = useQueryClient();
+
   const { mutate: submitQuiz, isLoading } = useMutation(
-    async (values: QuizSubmitRequest) => {
+    async (answer: QuizButtonType) => {
       try {
-        await postSubmitQuizByQuizId(values);
+        await postSubmitQuizByQuizId({ quizId, answer });
       } finally {
         router.refresh();
       }
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(QUERY_KEYS.GET_QUIZ_DETAIL(quizId));
+      },
     }
   );
 

--- a/src/app/quiz/hooks/useSubmitQuizMutation.ts
+++ b/src/app/quiz/hooks/useSubmitQuizMutation.ts
@@ -1,22 +1,20 @@
 'use client';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
 
 import { QUERY_KEYS } from '@/app/quiz/constants/queryKeys';
 import { QuizButtonType } from '@/app/quiz/models/quiz';
 import { postSubmitQuizByQuizId } from '@/app/quiz/remotes/quiz';
 
 export const useSubmitQuizMutation = (quizId: string) => {
-  const router = useRouter();
   const queryClient = useQueryClient();
 
   const { mutate: submitQuiz, isLoading } = useMutation(
     async (answer: QuizButtonType) => {
       try {
         await postSubmitQuizByQuizId({ quizId, answer });
-      } finally {
-        router.refresh();
+      } catch {
+        throw new Error('퀴즈 제출 요청에 실패하였습니다.');
       }
     },
     {

--- a/src/app/quiz/hooks/useSubmitQuizMutation.ts
+++ b/src/app/quiz/hooks/useSubmitQuizMutation.ts
@@ -7,7 +7,7 @@ import { QUERY_KEYS } from '@/app/quiz/constants/queryKeys';
 import { QuizButtonType } from '@/app/quiz/models/quiz';
 import { postSubmitQuizByQuizId } from '@/app/quiz/remotes/quiz';
 
-export const useSubmitQuizMutaion = (quizId: string) => {
+export const useSubmitQuizMutation = (quizId: string) => {
   const router = useRouter();
   const queryClient = useQueryClient();
 

--- a/src/app/quiz/models/quiz.ts
+++ b/src/app/quiz/models/quiz.ts
@@ -10,6 +10,10 @@ export interface QuizDetailResponse extends QuizResponse {
 
 export interface QuizRecommendResponse extends QuizResponse {}
 
+export interface QuizSubmitRequest {
+  answer: QuizButtonType;
+}
+
 export interface QuizResponse {
   quiz: Quiz;
   category: Category;

--- a/src/app/quiz/models/quiz.ts
+++ b/src/app/quiz/models/quiz.ts
@@ -11,6 +11,7 @@ export interface QuizDetailResponse extends QuizResponse {
 export interface QuizRecommendResponse extends QuizResponse {}
 
 export interface QuizSubmitRequest {
+  quizId: string;
   answer: QuizButtonType;
 }
 

--- a/src/app/quiz/models/quiz.ts
+++ b/src/app/quiz/models/quiz.ts
@@ -4,8 +4,8 @@ export type OX = 'O' | 'X';
 export type QuizButtonType = AB | OX;
 export type ButtonNumber = '1' | '2';
 
-export interface QuizDetailResponse extends QuizResponse {
-  isSubmitted: boolean;
+export interface QuizDetailResponse {
+  data: QuizResponse;
 }
 
 export interface QuizRecommendResponse extends QuizResponse {}

--- a/src/app/quiz/models/quiz.ts
+++ b/src/app/quiz/models/quiz.ts
@@ -1,5 +1,7 @@
 export type QuizType = 'A_B_IMAGE' | 'A_B_SIMPLE' | 'O_X_IMAGE' | 'O_X_SIMPLE';
-export type QuizButtonType = 'A' | 'B' | 'O' | 'X';
+export type AB = 'A' | 'B';
+export type OX = 'O' | 'X';
+export type QuizButtonType = AB | OX;
 export type ButtonNumber = '1' | '2';
 
 export interface QuizDetailResponse extends QuizResponse {

--- a/src/app/quiz/models/quiz.ts
+++ b/src/app/quiz/models/quiz.ts
@@ -14,7 +14,7 @@ export interface QuizResponse {
   quizReplyHistoryCount: number;
   quizCommentCount: number;
   answerReplyCount: number;
-  quizReply: QuizReply;
+  quizReply?: QuizReply;
   quizReplyCount: QuizReplyCount;
   isSubmitted: boolean;
 }
@@ -59,7 +59,7 @@ export interface QuizReply {
 export interface QuizReplyCount {
   totalCount: number;
   replyCount: {
-    [key in QuizButtonType]: ReplyCount;
+    [key in QuizButtonType]?: ReplyCount;
   };
 }
 

--- a/src/app/quiz/models/quiz.ts
+++ b/src/app/quiz/models/quiz.ts
@@ -1,4 +1,6 @@
 export type QuizType = 'A_B_IMAGE' | 'A_B_SIMPLE' | 'O_X_IMAGE' | 'O_X_SIMPLE';
+export type QuizButtonType = 'A' | 'B' | 'O' | 'X';
+export type ButtonNumber = '1' | '2';
 
 export interface QuizDetailResponse extends QuizResponse {
   isSubmitted: boolean;
@@ -11,6 +13,10 @@ export interface QuizResponse {
   category: Category;
   quizReplyHistoryCount: number;
   quizCommentCount: number;
+  answerReplyCount: number;
+  quizReply: QuizReply;
+  quizReplyCount: QuizReplyCount;
+  isSubmitted: boolean;
 }
 
 export interface Quiz {
@@ -28,8 +34,7 @@ export interface Question {
   question: string;
   imageUrl?: string;
   buttons: {
-    '1': QuizButton;
-    '2': QuizButton;
+    [key in ButtonNumber]: QuizButton;
   };
 }
 
@@ -43,4 +48,22 @@ export interface Category {
   depth: number;
   name: string;
   description: string;
+}
+
+export interface QuizReply {
+  id: number;
+  answer: string;
+  createdAt: string;
+}
+
+export interface QuizReplyCount {
+  totalCount: number;
+  replyCount: {
+    [key in QuizButtonType]: ReplyCount;
+  };
+}
+
+export interface ReplyCount {
+  answer: string;
+  count: number;
 }

--- a/src/app/quiz/models/quiz.ts
+++ b/src/app/quiz/models/quiz.ts
@@ -2,7 +2,6 @@ export type QuizType = 'A_B_IMAGE' | 'A_B_SIMPLE' | 'O_X_IMAGE' | 'O_X_SIMPLE';
 export type AB = 'A' | 'B';
 export type OX = 'O' | 'X';
 export type QuizButtonType = AB | OX;
-export type ButtonNumber = '1' | '2';
 
 export interface QuizDetailResponse {
   data: QuizResponse;
@@ -41,7 +40,7 @@ export interface Question {
   question: string;
   imageUrl?: string;
   buttons: {
-    [key in ButtonNumber]: QuizButton;
+    [key in QuizButtonType]: QuizButton;
   };
 }
 

--- a/src/app/quiz/remotes/quiz.ts
+++ b/src/app/quiz/remotes/quiz.ts
@@ -1,45 +1,8 @@
-// import { headers } from 'next/headers';
-
-import {
-  QuizDetailResponse,
-  QuizRecommendResponse,
-  QuizSubmitRequest,
-} from '@/app/quiz/models/quiz';
+import { QuizResponse, QuizSubmitRequest } from '@/app/quiz/models/quiz';
 import { http } from '@/common/utils/http';
 
-// function getToken() {
-//   // const headersInstance = headers();
-//   const authorization =
-//     'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJrYW5naGcxMTE2QG5hdmVyLmNvbSIsInVpZCI6NCwiaWF0IjoxNjg4MjI1NzM3LCJpc3MiOiI0IiwiZXhwIjoxNzE5NzYxNzM3fQ.sQVuFvrSpVaeCaDBAh1nrWdy-xgdWp-aE-J0K0DVEJ8'; //headersInstance.get('X-TOKS-AUTH-TOKEN');
-//   return authorization;
-// }
-
-// export const getQuizDetailByQuizId = async (quizId: string) => {
-//   const authorization = getToken();
-//   const result = await fetch(
-//     `${process.env.NEXT_PUBLIC_BASE_URL}api/v1/quizzes/${quizId}`,
-//     {
-//       cache: 'no-store',
-//       headers: {
-//         'Content-Type': 'application/json',
-//         ...(authorization
-//           ? { 'X-TOKS-AUTH-TOKEN': authorization as string }
-//           : {}),
-//       },
-//     }
-//   );
-//   const quizDetailInfo = await result.json();
-//   const quizDetail: QuizDetailResponse = quizDetailInfo.data;
-//   return quizDetail;
-// };
-
 export const getQuizDetailByQuizId = async (quizId: string) => {
-  console.log('DDDDDDD');
-  const { data } = await http.get<QuizDetailResponse>(
-    `api/v1/quizzes/${quizId}`
-  );
-  console.log(data);
-  return data;
+  return await http.get<QuizResponse>(`api/v1/quizzes/${quizId}`);
 };
 
 export const postSubmitQuizByQuizId = async ({
@@ -47,39 +10,4 @@ export const postSubmitQuizByQuizId = async ({
   answer,
 }: QuizSubmitRequest) => {
   return await http.post(`api/v1/quizzes/${quizId}`, { answer });
-};
-
-// 위 아래 둘 다 http 객체 이용하는거로 바꿔야 함. 클라이언트 컴포넌트에서 쓸거라서...
-
-// export const postSubmitQuizByQuizId = async (
-//   quizSubmitRequest: QuizSubmitRequest
-// ) => {
-//   const authorization = getToken();
-//   const result = await fetch(
-//     `${process.env.NEXT_PUBLIC_BASE_URL}api/v1/quizzes/${quizId}`,
-//     {
-//       method: 'POST',
-//       headers: {
-//         'Content-Type': 'application/json',
-//         ...(authorization
-//           ? { 'X-TOKS-AUTH-TOKEN': authorization as string }
-//           : {}),
-//       },
-//       body: JSON.stringify(quizSubmitRequest),
-//     }
-//   );
-//   return result;
-// };
-
-export const getRecommendationByQuizId = async (quizId: string) => {
-  const result = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_URL}api/v1/rec/quizzes?quizId=${quizId}`,
-    {
-      cache: 'force-cache',
-    }
-  );
-  const quizRecommendInfo = await result.json();
-  const quizRecommendModels: QuizRecommendResponse[] =
-    quizRecommendInfo.data.quizRecommendModels;
-  return quizRecommendModels;
 };

--- a/src/app/quiz/remotes/quiz.ts
+++ b/src/app/quiz/remotes/quiz.ts
@@ -1,9 +1,27 @@
+// import { headers } from 'next/headers';
+
 import { QuizDetailResponse, QuizRecommendResponse } from '../models/quiz';
 
+function getToken() {
+  // const headersInstance = headers();
+  const authorization =
+    'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJrYW5naGcxMTE2QG5hdmVyLmNvbSIsInVpZCI6NCwiaWF0IjoxNjg4MjI1NzM3LCJpc3MiOiI0IiwiZXhwIjoxNzE5NzYxNzM3fQ.sQVuFvrSpVaeCaDBAh1nrWdy-xgdWp-aE-J0K0DVEJ8'; //headersInstance.get('X-TOKS-AUTH-TOKEN');
+  return authorization;
+}
+
 export const getQuizDetailByQuizId = async (quizId: string) => {
+  const authorization = getToken();
   const result = await fetch(
     `${process.env.NEXT_PUBLIC_BASE_URL}api/v1/quizzes/${quizId}`,
-    { cache: 'no-store' }
+    {
+      cache: 'no-store',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(authorization
+          ? { 'X-TOKS-AUTH-TOKEN': authorization as string }
+          : {}),
+      },
+    }
   );
   const quizDetailInfo = await result.json();
   const quizDetail: QuizDetailResponse = quizDetailInfo.data;
@@ -13,7 +31,9 @@ export const getQuizDetailByQuizId = async (quizId: string) => {
 export const getRecommendationByQuizId = async (quizId: string) => {
   const result = await fetch(
     `${process.env.NEXT_PUBLIC_BASE_URL}api/v1/rec/quizzes?quizId=${quizId}`,
-    { cache: 'force-cache' }
+    {
+      cache: 'force-cache',
+    }
   );
   const quizRecommendInfo = await result.json();
   const quizRecommendModels: QuizRecommendResponse[] =

--- a/src/app/quiz/remotes/quiz.ts
+++ b/src/app/quiz/remotes/quiz.ts
@@ -1,6 +1,10 @@
 // import { headers } from 'next/headers';
 
-import { QuizDetailResponse, QuizRecommendResponse } from '../models/quiz';
+import {
+  QuizButtonType,
+  QuizDetailResponse,
+  QuizRecommendResponse,
+} from '@/app/quiz/models/quiz';
 
 function getToken() {
   // const headersInstance = headers();
@@ -26,6 +30,29 @@ export const getQuizDetailByQuizId = async (quizId: string) => {
   const quizDetailInfo = await result.json();
   const quizDetail: QuizDetailResponse = quizDetailInfo.data;
   return quizDetail;
+};
+
+export const postSubmitQuizByQuizId = async (
+  quizId: string,
+  answer: QuizButtonType
+) => {
+  const authorization = getToken();
+  const result = await fetch(
+    `${process.env.NEXT_PUBLIC_BASE_URL}api/v1/quizzes/${quizId}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(authorization
+          ? { 'X-TOKS-AUTH-TOKEN': authorization as string }
+          : {}),
+      },
+      body: JSON.stringify({
+        answer,
+      }),
+    }
+  );
+  return result;
 };
 
 export const getRecommendationByQuizId = async (quizId: string) => {

--- a/src/app/quiz/remotes/quiz.ts
+++ b/src/app/quiz/remotes/quiz.ts
@@ -34,7 +34,10 @@ import { http } from '@/common/utils/http';
 // };
 
 export const getQuizDetailByQuizId = async (quizId: string) => {
-  return await http.get<QuizDetailResponse>(`api/v1/quizzes/${quizId}`);
+  const { data } = await http.get<QuizDetailResponse>(
+    `api/v1/quizzes/${quizId}`
+  );
+  return data;
 };
 
 export const postSubmitQuizByQuizId = async ({

--- a/src/app/quiz/remotes/quiz.ts
+++ b/src/app/quiz/remotes/quiz.ts
@@ -4,6 +4,7 @@ import {
   QuizButtonType,
   QuizDetailResponse,
   QuizRecommendResponse,
+  QuizSubmitRequest,
 } from '@/app/quiz/models/quiz';
 
 function getToken() {
@@ -32,9 +33,10 @@ export const getQuizDetailByQuizId = async (quizId: string) => {
   return quizDetail;
 };
 
+// 위 아래 둘 다 http 객체 이용하는거로 바꿔야 함. 클라이언트 컴포넌트에서 쓸거라서...
+
 export const postSubmitQuizByQuizId = async (
-  quizId: string,
-  answer: QuizButtonType
+  quizSubmitRequest: QuizSubmitRequest
 ) => {
   const authorization = getToken();
   const result = await fetch(
@@ -47,9 +49,7 @@ export const postSubmitQuizByQuizId = async (
           ? { 'X-TOKS-AUTH-TOKEN': authorization as string }
           : {}),
       },
-      body: JSON.stringify({
-        answer,
-      }),
+      body: JSON.stringify(quizSubmitRequest),
     }
   );
   return result;

--- a/src/app/quiz/remotes/quiz.ts
+++ b/src/app/quiz/remotes/quiz.ts
@@ -34,9 +34,11 @@ import { http } from '@/common/utils/http';
 // };
 
 export const getQuizDetailByQuizId = async (quizId: string) => {
+  console.log('DDDDDDD');
   const { data } = await http.get<QuizDetailResponse>(
     `api/v1/quizzes/${quizId}`
   );
+  console.log(data);
   return data;
 };
 

--- a/src/app/quiz/remotes/quiz.ts
+++ b/src/app/quiz/remotes/quiz.ts
@@ -1,59 +1,70 @@
 // import { headers } from 'next/headers';
 
 import {
-  QuizButtonType,
   QuizDetailResponse,
   QuizRecommendResponse,
   QuizSubmitRequest,
 } from '@/app/quiz/models/quiz';
+import { http } from '@/common/utils/http';
 
-function getToken() {
-  // const headersInstance = headers();
-  const authorization =
-    'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJrYW5naGcxMTE2QG5hdmVyLmNvbSIsInVpZCI6NCwiaWF0IjoxNjg4MjI1NzM3LCJpc3MiOiI0IiwiZXhwIjoxNzE5NzYxNzM3fQ.sQVuFvrSpVaeCaDBAh1nrWdy-xgdWp-aE-J0K0DVEJ8'; //headersInstance.get('X-TOKS-AUTH-TOKEN');
-  return authorization;
-}
+// function getToken() {
+//   // const headersInstance = headers();
+//   const authorization =
+//     'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJrYW5naGcxMTE2QG5hdmVyLmNvbSIsInVpZCI6NCwiaWF0IjoxNjg4MjI1NzM3LCJpc3MiOiI0IiwiZXhwIjoxNzE5NzYxNzM3fQ.sQVuFvrSpVaeCaDBAh1nrWdy-xgdWp-aE-J0K0DVEJ8'; //headersInstance.get('X-TOKS-AUTH-TOKEN');
+//   return authorization;
+// }
+
+// export const getQuizDetailByQuizId = async (quizId: string) => {
+//   const authorization = getToken();
+//   const result = await fetch(
+//     `${process.env.NEXT_PUBLIC_BASE_URL}api/v1/quizzes/${quizId}`,
+//     {
+//       cache: 'no-store',
+//       headers: {
+//         'Content-Type': 'application/json',
+//         ...(authorization
+//           ? { 'X-TOKS-AUTH-TOKEN': authorization as string }
+//           : {}),
+//       },
+//     }
+//   );
+//   const quizDetailInfo = await result.json();
+//   const quizDetail: QuizDetailResponse = quizDetailInfo.data;
+//   return quizDetail;
+// };
 
 export const getQuizDetailByQuizId = async (quizId: string) => {
-  const authorization = getToken();
-  const result = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_URL}api/v1/quizzes/${quizId}`,
-    {
-      cache: 'no-store',
-      headers: {
-        'Content-Type': 'application/json',
-        ...(authorization
-          ? { 'X-TOKS-AUTH-TOKEN': authorization as string }
-          : {}),
-      },
-    }
-  );
-  const quizDetailInfo = await result.json();
-  const quizDetail: QuizDetailResponse = quizDetailInfo.data;
-  return quizDetail;
+  return await http.get<QuizDetailResponse>(`api/v1/quizzes/${quizId}`);
+};
+
+export const postSubmitQuizByQuizId = async ({
+  quizId,
+  answer,
+}: QuizSubmitRequest) => {
+  return await http.post(`api/v1/quizzes/${quizId}`, { answer });
 };
 
 // 위 아래 둘 다 http 객체 이용하는거로 바꿔야 함. 클라이언트 컴포넌트에서 쓸거라서...
 
-export const postSubmitQuizByQuizId = async (
-  quizSubmitRequest: QuizSubmitRequest
-) => {
-  const authorization = getToken();
-  const result = await fetch(
-    `${process.env.NEXT_PUBLIC_BASE_URL}api/v1/quizzes/${quizId}`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        ...(authorization
-          ? { 'X-TOKS-AUTH-TOKEN': authorization as string }
-          : {}),
-      },
-      body: JSON.stringify(quizSubmitRequest),
-    }
-  );
-  return result;
-};
+// export const postSubmitQuizByQuizId = async (
+//   quizSubmitRequest: QuizSubmitRequest
+// ) => {
+//   const authorization = getToken();
+//   const result = await fetch(
+//     `${process.env.NEXT_PUBLIC_BASE_URL}api/v1/quizzes/${quizId}`,
+//     {
+//       method: 'POST',
+//       headers: {
+//         'Content-Type': 'application/json',
+//         ...(authorization
+//           ? { 'X-TOKS-AUTH-TOKEN': authorization as string }
+//           : {}),
+//       },
+//       body: JSON.stringify(quizSubmitRequest),
+//     }
+//   );
+//   return result;
+// };
 
 export const getRecommendationByQuizId = async (quizId: string) => {
   const result = await fetch(

--- a/src/app/quiz/remotes/recommendation.ts
+++ b/src/app/quiz/remotes/recommendation.ts
@@ -1,0 +1,14 @@
+import { QuizRecommendResponse } from '@/app/quiz/models/quiz';
+
+export const getRecommendationByQuizId = async (quizId: string) => {
+  const result = await fetch(
+    `${process.env.NEXT_PUBLIC_BASE_URL}api/v1/rec/quizzes?quizId=${quizId}`,
+    {
+      cache: 'force-cache',
+    }
+  );
+  const quizRecommendInfo = await result.json();
+  const quizRecommendModels: QuizRecommendResponse[] =
+    quizRecommendInfo.data.quizRecommendModels;
+  return quizRecommendModels;
+};

--- a/src/queries/useQuizListInfinityQuery/index.ts
+++ b/src/queries/useQuizListInfinityQuery/index.ts
@@ -26,17 +26,19 @@ export const useQuizListInfinityQuery = () => {
         if (quiz.question.imageUrl) {
           imageArray.push(quiz.question.imageUrl);
         }
-        // if (quiz.question.buttons[1].imageUrl) {
-        //   imageArray.push(quiz.question.buttons[1].imageUrl);
-        // }
-        // if (quiz.question.buttons[2].imageUrl) {
-        //   imageArray.push(quiz.question.buttons[2].imageUrl);
-        // }
-        imageArray.push(
-          ...(Object.values(quiz.question.buttons)
-            .map((button) => button?.imageUrl)
-            .filter((imageUrl) => imageUrl !== undefined) as string[])
-        );
+        if (quiz.question.buttons.A.imageUrl) {
+          imageArray.push(quiz.question.buttons.A.imageUrl);
+        }
+        if (quiz.question.buttons.B.imageUrl) {
+          imageArray.push(quiz.question.buttons.B.imageUrl);
+        }
+        if (quiz.question.buttons.O.imageUrl) {
+          imageArray.push(quiz.question.buttons.O.imageUrl);
+        }
+        if (quiz.question.buttons.X.imageUrl) {
+          imageArray.push(quiz.question.buttons.X.imageUrl);
+        }
+
         return imageArray;
       };
 

--- a/src/queries/useQuizListInfinityQuery/index.ts
+++ b/src/queries/useQuizListInfinityQuery/index.ts
@@ -26,12 +26,17 @@ export const useQuizListInfinityQuery = () => {
         if (quiz.question.imageUrl) {
           imageArray.push(quiz.question.imageUrl);
         }
-        if (quiz.question.buttons[1].imageUrl) {
-          imageArray.push(quiz.question.buttons[1].imageUrl);
-        }
-        if (quiz.question.buttons[2].imageUrl) {
-          imageArray.push(quiz.question.buttons[2].imageUrl);
-        }
+        // if (quiz.question.buttons[1].imageUrl) {
+        //   imageArray.push(quiz.question.buttons[1].imageUrl);
+        // }
+        // if (quiz.question.buttons[2].imageUrl) {
+        //   imageArray.push(quiz.question.buttons[2].imageUrl);
+        // }
+        imageArray.push(
+          ...(Object.values(quiz.question.buttons)
+            .map((button) => button?.imageUrl)
+            .filter((imageUrl) => imageUrl !== undefined) as string[])
+        );
         return imageArray;
       };
 


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
- 퀴즈 제출 기능을 구현했습니다.
- 기존 서버 컴포넌트로 영역을 리-렌더링 하려면 router를 사용해야 하는데 router는 서버컴포넌트에선 사용할 수 없는 문제가 있었습니다. (리-렌더 하는 로직이 퀴즈 상세 영역(서버컴포넌트) 안에서 이루어져야 했습니다.)
- 따라서 퀴즈 상세 영역 자체를 클라이언트 컴포넌트로 전환하고 데이터 페칭, 퀴즈 제출 요청, 리-렌더링 전부 tanstack-query를 사용하여 해결했습니다.

## 💁 무엇이 어떻게 바뀌나요?
구현한 화면은 기존에 올린 내용과 변한게 없는데 퀴즈 제출하는 순간을 영상 캡쳐를 못했네요 ㅠ
- 디자인 레퍼런스:
- 관련 슬랙 링크:

## 💬 리뷰어분들께
이번에 구현하면서 useQuery와 useMutation을 이용하는게 익숙치 않았는데 잘 못 작성한 부분이 있을 수 있을거 같아요
감안해서 봐주시고 피드백 해주시면 감사드리겠습니다!🙇‍♂️

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->
