### PR TITLE
feat(toks-components): BottomSheet 등장문제, 애니메이션 효과 문제 해결, Dimmer추가

### DIFF
--- a/src/app/quiz/[quizId]/@detail/page.tsx
+++ b/src/app/quiz/[quizId]/@detail/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import clsx from 'clsx';
+import { useState } from 'react';
 
 import { QuizButton, Thumbnail } from '@/app/quiz/components';
 import {
@@ -8,7 +9,7 @@ import {
   useSubmitQuizMutation,
 } from '@/app/quiz/hooks/';
 import { QuizButtonType } from '@/app/quiz/models/quiz';
-import { Text, bgColor } from '@/common';
+import { BottomSheet, Button, Text, bgColor } from '@/common';
 
 type Props = {
   params: {
@@ -19,6 +20,7 @@ type Props = {
 function DetailPage({ params: { quizId } }: Props) {
   const { submitQuiz } = useSubmitQuizMutation(quizId);
   const { data: quizDetail } = useGetQuizDetailQuery(quizId);
+  const [isShow, setIsShow] = useState(false);
 
   if (quizDetail === undefined) {
     return null;
@@ -43,13 +45,22 @@ function DetailPage({ params: { quizId } }: Props) {
   const isExistOXImage = Boolean(oxImageUrl);
   const isVisibleOXImage = !isSubmitted && isExistOXImage;
   const replyAnswer = quizReply?.answer;
-  const isOXCorrectAnswer = replyAnswer === oxAnswer; // 퀴즈의 정답이 1혹은 2 사용자의 답안은 O혹은 X로 넘어오는 문제 해결 안된 상태
+  const isOXCorrectAnswer = replyAnswer === oxAnswer;
   const checkSameQuizType = (type: string) => quizType.startsWith(type);
   const checkSelectedAnswer = (buttonType: QuizButtonType) =>
     replyAnswer === buttonType;
 
   return (
     <section className={clsx(bgColor['gray110'], 'mt-8px rounded-16px p-20px')}>
+      <Button
+        backgroundColor="primaryDefault"
+        textColor="gray10"
+        onClick={() => {
+          setIsShow(true);
+        }}
+      >
+        임시
+      </Button>
       <div className="flex gap-8px">
         {[categoryName, ...tags].map((tagName, index) => (
           <Text
@@ -133,6 +144,9 @@ function DetailPage({ params: { quizId } }: Props) {
           )}
         </div>
       </div>
+      <BottomSheet onClose={() => setIsShow(false)} isShow={isShow}>
+        <h1>hi</h1>
+      </BottomSheet>
     </section>
   );
 }

--- a/src/common/components/BottomSheet/index.tsx
+++ b/src/common/components/BottomSheet/index.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import clsx from 'clsx';
 import React, { PropsWithChildren } from 'react';
 
-import { useClickAway } from '@/common/hooks/useClickAway';
+// import { useClickAway } from '@/common/hooks/useClickAway';
+import { cn } from '@/common/utils';
 
 import { BottomSheetProps } from './types';
 import { GlobalPortal } from '../GlobalPortal';
@@ -13,24 +13,51 @@ export const BottomSheet = ({
   children,
   onClose,
 }: PropsWithChildren<BottomSheetProps>) => {
-  const bottomSheetContentRef = useClickAway({
-    callback: () => {
-      onClose();
-    },
-  });
+  // const bottomSheetContentRef = useClickAway({
+  //   callback: () => {
+  //     onClose();
+  //   },
+  // });
   return (
     <GlobalPortal.Consumer>
+      <Dimmer isShow={isShow} onClose={onClose} />
       <div
-        ref={bottomSheetContentRef}
-        className={clsx(
-          'fixed bottom-0 left-0 right-0 z-50 h-486px w-full translate-y-full rounded-tl-16px rounded-tr-16px bg-gray-90 transition-transform duration-75',
+        // ref={bottomSheetContentRef}
+        style={{
+          transition: 'transform 0.3s ease-out',
+        }}
+        className={cn(
+          'fixed bottom-0 left-0 right-0 z-50 h-486px w-full translate-y-full rounded-tl-16px rounded-tr-16px bg-gray-90',
           {
-            'translate-y-0 animate-slide-up-bottom-sheet': isShow,
+            'translate-y-0': isShow, //animate-slide-up-bottom-sheet
           }
         )}
       >
         {children}
       </div>
     </GlobalPortal.Consumer>
+  );
+};
+
+const Dimmer = ({
+  isShow,
+  onClose,
+}: {
+  isShow: boolean;
+  onClose: VoidFunction;
+}) => {
+  return (
+    <div
+      onClick={() => {
+        onClose();
+      }}
+      className={cn(
+        'fixed left-0 top-0 z-50 flex h-full w-full items-center justify-center bg-gray-120/80',
+        {
+          hidden: !isShow,
+          'animate-fade-in-back-drop': isShow,
+        }
+      )}
+    />
   );
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,7 +13,6 @@ const {
 module.exports = {
   important: true,
   content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
-  important: true,
   theme: {
     extend: {
       colors,


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
- 바텀시트 높이가 486px보다 커질 수 있어서 안에 들어가는 요소의 크기로 높이를 결정해야 할 것 같습니다
- 바텀시트 내부의 className에 clsx사용으로 인해 isShow로 인한 스타일 분기가 이루어지지 않아 cn으로 교체했습니다.
- animate-slide-up-bottom-sheet 여기에 정의된 애니메이션 효과가 올라갈때도, 내려갈때도 적용되지 않아서 일단은 지우고 inline-style 방식으로 transition을 정의해주니 해결되었습니다.
- 바텀시트 등장시 Dimmer가 필요할거 같아서 추가했습니다. (0.3초동안 fade-in-out 애니메이션 적용)
- useClickAway를 통해 바텀시트 외 영역 클릭시 닫히는 효과가 구현되어 있었는데 바텀시트와 Dimmer가 화면에 표시된 채로 영상의 ‘임시’ 버튼을 누르게되면 클릭이 되는 문제가 있었습니다.
- 따라서 바텀시트 등장된 상태로 ‘임시’버튼을 클릭하면 바텀시트가 잠깐 들어갔다가 다시 나오는 문제가 생겼습니다.
- 일단 해결하고자 onClose로 받은 함수를 useClickAway를 사용 안하고 Dimmer의 클릭이벤트로 넘겨주니 해결되었습니다

## 💁 무엇이 어떻게 바뀌나요?

- 디자인 레퍼런스:
- 관련 슬랙 링크: https://5gaeanmal.slack.com/archives/C048PJ7E7FX/p1693044127101219

## 💬 리뷰어분들께
슬랙 링크 참고해주시면 좋을 것 같습니다-!

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->
