### PR TITLE
feat(toks-main, my-page): toast component 적용

### DIFF
--- a/src/app/kakao-auth/page.tsx
+++ b/src/app/kakao-auth/page.tsx
@@ -7,24 +7,38 @@ import { useEffect, useState } from 'react';
 
 import { getUserInfo } from '@/common';
 import { QUERY_KEYS } from '@/common/constants/queryKeys';
+import { useToast } from '@/common/hooks/useToast';
 import { isToksError } from '@/common/utils/http';
 
 const KakaoAuth = () => {
   const params = useSearchParams();
   const router = useRouter();
   const [accessToken, setAccessToken] = useState<string | null>('');
+  const [refreshToken, setRefreshToken] = useState<string | null>('');
+
+  const { saveToastInfo, clearSavedToast } = useToast();
 
   useEffect(() => {
     setAccessToken(params.get('accessToken'));
-    const refreshToken = params.get('refreshToken');
-
+    setRefreshToken(params.get('refreshToken'));
     if (accessToken && refreshToken) {
       deleteCookie('accessToken');
       deleteCookie('refreshToken');
       setCookie('accessToken', accessToken);
       setCookie('refreshToken', refreshToken);
     }
-  }, [params, router, accessToken]);
+  }, [params, router, accessToken, refreshToken]);
+
+  if (accessToken && refreshToken) {
+    clearSavedToast();
+    saveToastInfo({
+      showOnNextPage: true,
+      isShow: true,
+      direction: 'top',
+      type: 'success',
+      title: '로그인을 성공했어요.',
+    });
+  }
 
   const { data: user, isError } = useQuery(
     QUERY_KEYS.GET_USER_INFO(accessToken),

--- a/src/app/kakao-auth/page.tsx
+++ b/src/app/kakao-auth/page.tsx
@@ -34,7 +34,7 @@ const KakaoAuth = () => {
     saveToastInfo({
       showOnNextPage: true,
       isShow: true,
-      direction: 'top',
+      direction: 'bottom',
       type: 'success',
       title: '로그인을 성공했어요.',
     });

--- a/src/app/my-page/page.tsx
+++ b/src/app/my-page/page.tsx
@@ -1,14 +1,34 @@
+'use client';
 import Image from 'next/image';
+import { useEffect, useState } from 'react';
 
-import { Button, ICON_URL, Text } from '@/common';
+import { Button, ICON_URL, Text, Toast, ToastProps } from '@/common';
+import { useToast } from '@/common/hooks/useToast';
 
 import { BackHeader } from './components/BackHeader';
 import { LogoutBar } from './components/LogoutBar';
 import { UserInfo } from './components/UserInfo';
 
 const MyPage = () => {
+  const [toastData, setToastData] = useState<ToastProps | null>(null);
+  const { getSavedToastInfo, clearSavedToast } = useToast();
+
+  useEffect(() => {
+    setToastData(getSavedToastInfo());
+    clearSavedToast();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <div>
+      {toastData && (
+        <Toast
+          isShow={toastData.isShow}
+          type={toastData.type}
+          direction={toastData.direction}
+          title={toastData.title}
+        />
+      )}
       <BackHeader />
       <UserInfo />
       <div className="h-40px" />

--- a/src/app/nickname/hooks/useCreateNicknameForm.ts
+++ b/src/app/nickname/hooks/useCreateNicknameForm.ts
@@ -12,7 +12,7 @@ export interface CheckNicknameFormValues {
   nickname: string;
 }
 
-export const useCreateNicknameForm = () => {
+export const useCreateNicknameForm = (pathName: string) => {
   const {
     register,
     getValues,
@@ -56,11 +56,13 @@ export const useCreateNicknameForm = () => {
         saveToastInfo({
           showOnNextPage: true,
           isShow: true,
-          direction: 'top',
+          direction: 'bottom',
           type: 'success',
           title: '닉네임 설정을 완료하였어요.',
         });
-        router.replace('/toks-main');
+        pathName === '/nickname/update'
+          ? router.replace('/my-page')
+          : router.replace('/toks-main');
       }
     } catch (err: unknown) {
       if (isToksError(err) && err.errorCode === 'DUPLICATED_NICKNAME') {

--- a/src/app/nickname/hooks/useCreateNicknameForm.ts
+++ b/src/app/nickname/hooks/useCreateNicknameForm.ts
@@ -3,6 +3,7 @@ import { useRouter } from 'next/navigation';
 import { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
 
+import { useToast } from '@/common/hooks/useToast';
 import { isToksError } from '@/common/utils/http';
 
 import { patchNickname } from '../remotes/nickname';
@@ -23,6 +24,7 @@ export const useCreateNicknameForm = () => {
 
   const isDisabled = !isDirty || !isValid;
   const router = useRouter();
+  const { saveToastInfo, clearSavedToast } = useToast();
 
   const isMaxLength = useCallback((maxLength: number) => {
     return {
@@ -50,6 +52,14 @@ export const useCreateNicknameForm = () => {
     try {
       const res = await patchNickname(nickname);
       if (res !== null) {
+        clearSavedToast();
+        saveToastInfo({
+          showOnNextPage: true,
+          isShow: true,
+          direction: 'top',
+          type: 'success',
+          title: '닉네임 설정을 완료하였어요.',
+        });
         router.replace('/toks-main');
       }
     } catch (err: unknown) {

--- a/src/app/nickname/page.tsx
+++ b/src/app/nickname/page.tsx
@@ -1,11 +1,14 @@
 'use client';
 
+import { usePathname } from 'next/navigation';
+
 import { Button } from '@/common';
 
 import { NicknameBox } from './components/NicknameBox';
 import { useCreateNicknameForm } from './hooks/useCreateNicknameForm';
 
 const Nickname = () => {
+  const pathName = usePathname();
   const {
     register,
     errors,
@@ -15,7 +18,7 @@ const Nickname = () => {
     isRequiredText,
     hasExclamationMark,
     nicknameMutation,
-  } = useCreateNicknameForm();
+  } = useCreateNicknameForm(pathName);
 
   return (
     <div className="relative h-main pt-86px">

--- a/src/app/nickname/update/page.tsx
+++ b/src/app/nickname/update/page.tsx
@@ -2,6 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { getCookie } from 'cookies-next';
+import { usePathname } from 'next/navigation';
 
 import { Button, getUserInfo } from '@/common';
 import { QUERY_KEYS } from '@/common/constants/queryKeys';
@@ -10,6 +11,7 @@ import { NicknameBox } from '../components/NicknameBox';
 import { useCreateNicknameForm } from '../hooks/useCreateNicknameForm';
 
 const UpdateNickname = () => {
+  const pathName = usePathname();
   const accessToken = getCookie('accessToken') as string;
 
   const {
@@ -29,7 +31,7 @@ const UpdateNickname = () => {
     isRequiredText,
     hasExclamationMark,
     nicknameMutation,
-  } = useCreateNicknameForm();
+  } = useCreateNicknameForm(pathName);
 
   return (
     <div className="relative h-main pt-86px">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 
-import { Text, Toast, Tooltip } from '@/common';
+import { Text, Tooltip } from '@/common';
 
 export default function Home() {
   const router = useRouter();
@@ -27,13 +27,6 @@ export default function Home() {
           Tooltips!!
         </Text>
       </Tooltip>
-      <Toast
-        showOnNextPage={true}
-        isShow={true}
-        direction="top"
-        type="failed"
-        title="로그인 실패"
-      />
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,9 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 
-import { Text } from '@/common';
-import { Toast } from '@/common/components/Toast';
-import { Tooltip } from '@/common/components/Tooltip';
+import { Text, Toast, Tooltip } from '@/common';
 
 export default function Home() {
   const router = useRouter();
@@ -29,7 +27,13 @@ export default function Home() {
           Tooltips!!
         </Text>
       </Tooltip>
-      <Toast isShow={true} direction="top" type="failed" title="로그인 실패" />
+      <Toast
+        showOnNextPage={true}
+        isShow={true}
+        direction="top"
+        type="failed"
+        title="로그인 실패"
+      />
     </div>
   );
 }

--- a/src/app/toks-main/page.tsx
+++ b/src/app/toks-main/page.tsx
@@ -10,8 +10,6 @@ function ToksMainPage() {
   const { getSavedToastInfo, clearSavedToast } = useToast();
   const [toastData, setToastData] = useState<ToastProps | null>(null);
 
-  console.log(toastData);
-
   useEffect(() => {
     setToastData(getSavedToastInfo());
     clearSavedToast();

--- a/src/app/toks-main/page.tsx
+++ b/src/app/toks-main/page.tsx
@@ -1,10 +1,31 @@
-import { FloatingButton } from '@/common';
+'use client';
+import { useEffect, useState } from 'react';
+
+import { FloatingButton, Toast } from '@/common';
+import { useToast } from '@/common/hooks/useToast';
 
 import { CardList } from './components/CardList';
 
 function ToksMainPage() {
+  const { getSavedToastInfo, clearSavedToast } = useToast();
+  const [toastData, setToastData] = useState<any>();
+
+  useEffect(() => {
+    setToastData(getSavedToastInfo());
+    clearSavedToast();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   return (
     <div>
+      {toastData && (
+        <Toast
+          isShow={toastData.isShow}
+          type={toastData.type}
+          direction={toastData.top}
+          title={toastData.title}
+        />
+      )}
       <CardList />
       <FloatingButton />
     </div>

--- a/src/app/toks-main/page.tsx
+++ b/src/app/toks-main/page.tsx
@@ -1,14 +1,16 @@
 'use client';
 import { useEffect, useState } from 'react';
 
-import { FloatingButton, Toast } from '@/common';
+import { FloatingButton, Toast, ToastProps } from '@/common';
 import { useToast } from '@/common/hooks/useToast';
 
 import { CardList } from './components/CardList';
 
 function ToksMainPage() {
   const { getSavedToastInfo, clearSavedToast } = useToast();
-  const [toastData, setToastData] = useState<any>();
+  const [toastData, setToastData] = useState<ToastProps | null>(null);
+
+  console.log(toastData);
 
   useEffect(() => {
     setToastData(getSavedToastInfo());
@@ -22,7 +24,7 @@ function ToksMainPage() {
         <Toast
           isShow={toastData.isShow}
           type={toastData.type}
-          direction={toastData.top}
+          direction={toastData.direction}
           title={toastData.title}
         />
       )}

--- a/src/common/components/Toast/index.tsx
+++ b/src/common/components/Toast/index.tsx
@@ -15,7 +15,7 @@ const VERTICAL = ['top', 'bottom'] as const;
 type VerticalDirection = (typeof VERTICAL)[number];
 export type ToastType = 'success' | 'failed';
 
-interface ToastProps {
+export interface ToastProps {
   type: ToastType;
   title?: string;
   direction?: VerticalDirection;
@@ -48,7 +48,15 @@ export const Toast = ({
   const { saveToastInfo } = useToast();
   const [isOpen, setIsOpen] = useState(isShow);
   if (showOnNextPage) {
-    saveToastInfo({ type, time: TOAST_OPENED_TIME, showOnNextPage: false });
+    saveToastInfo({
+      type,
+      isShow,
+      title,
+      direction,
+      time: TOAST_OPENED_TIME,
+      showOnNextPage: false,
+    });
+    return null;
   }
   return (
     <GlobalPortal.Consumer>

--- a/src/common/components/Toast/index.tsx
+++ b/src/common/components/Toast/index.tsx
@@ -4,7 +4,6 @@ import Image from 'next/image';
 import { ReactNode, useState } from 'react';
 
 import { ICON_URL } from '@/common/constants';
-import { useToast } from '@/common/hooks/useToast';
 import { cn } from '@/common/utils';
 
 import { GlobalPortal } from '../GlobalPortal';
@@ -43,21 +42,9 @@ export const Toast = ({
   //   TODO: 추후 변경될 가능성 생각하여 반영
   direction = 'bottom',
   time = TOAST_OPENED_TIME,
-  showOnNextPage,
 }: ToastProps) => {
-  const { saveToastInfo } = useToast();
   const [isOpen, setIsOpen] = useState(isShow);
-  if (showOnNextPage) {
-    saveToastInfo({
-      type,
-      isShow,
-      title,
-      direction,
-      time: TOAST_OPENED_TIME,
-      showOnNextPage: false,
-    });
-    return null;
-  }
+
   return (
     <GlobalPortal.Consumer>
       <AnimatePresence>

--- a/src/common/components/Toast/index.tsx
+++ b/src/common/components/Toast/index.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { ReactNode, useState } from 'react';
 
 import { ICON_URL } from '@/common/constants';
+import { useToast } from '@/common/hooks/useToast';
 import { cn } from '@/common/utils';
 
 import { GlobalPortal } from '../GlobalPortal';
@@ -12,15 +13,16 @@ import { Text } from '../Text';
 const VERTICAL = ['top', 'bottom'] as const;
 
 type VerticalDirection = (typeof VERTICAL)[number];
-type ToastType = 'success' | 'failed';
+export type ToastType = 'success' | 'failed';
 
 interface ToastProps {
   type: ToastType;
-  title: string;
+  title?: string;
   direction?: VerticalDirection;
   icon?: ReactNode;
   time?: number;
-  isShow: boolean;
+  isShow?: boolean;
+  showOnNextPage?: boolean;
 }
 const TOAST_OPENED_TIME = 3_000;
 
@@ -41,8 +43,13 @@ export const Toast = ({
   //   TODO: 추후 변경될 가능성 생각하여 반영
   direction = 'bottom',
   time = TOAST_OPENED_TIME,
+  showOnNextPage,
 }: ToastProps) => {
+  const { saveToastInfo } = useToast();
   const [isOpen, setIsOpen] = useState(isShow);
+  if (showOnNextPage) {
+    saveToastInfo({ type, time: TOAST_OPENED_TIME, showOnNextPage: false });
+  }
   return (
     <GlobalPortal.Consumer>
       <AnimatePresence>

--- a/src/common/components/Toast/index.tsx
+++ b/src/common/components/Toast/index.tsx
@@ -61,7 +61,7 @@ export const Toast = ({
             <div
               className={cn(
                 TOAST_DIRECTION[direction],
-                'fixed right-2/4 z-50 flex w-fit translate-x-2/4 gap-6px rounded-8px bg-gray-90 px-24px py-12px'
+                'fixed right-2/4 z-50 box-border flex w-max translate-x-2/4 gap-6px rounded-8px bg-gray-90 px-24px py-12px'
               )}
             >
               <Image
@@ -70,7 +70,11 @@ export const Toast = ({
                 src={TOAST_ICON[type]}
                 alt="버튼 아이콘 입니다."
               />
-              <Text typo="subheading" color="white">
+              <Text
+                className="whitespace-nowrap"
+                typo="subheading"
+                color="white"
+              >
                 {title}
               </Text>
             </div>

--- a/src/common/components/index.ts
+++ b/src/common/components/index.ts
@@ -13,3 +13,4 @@ export * from './Tooltip';
 export * from './SSRSuspense';
 export * from './GlobalPortal';
 export * from './TextField';
+export * from './Toast';

--- a/src/common/hooks/useToast.ts
+++ b/src/common/hooks/useToast.ts
@@ -1,0 +1,39 @@
+import { ComponentProps } from 'react';
+
+import { Toast, ToastType } from '../components/Toast';
+
+const LOCAL_STORAGE_KEY = '@depromeet/toast-key';
+
+interface Props extends ComponentProps<typeof Toast> {
+  type: ToastType;
+  time?: number;
+  showOnNextPage?: boolean;
+}
+
+export const useToast = () => {
+  const saveToastInfo = (info: Props) => {
+    const prevData = window.localStorage.getItem(LOCAL_STORAGE_KEY);
+
+    if (prevData != null) {
+      /**
+       * @Note 실제 런타임에서 동작을 방해할 수 있으므로, 에러를 throw 하지는 않습니다.
+       */
+      console.error(
+        '이전에 이미 저장된 토스트 정보가 있습니다. 의도된 동작이라면, 저장된 토스트 정보를 지우고 새로운 정보를 저장하세요.'
+      );
+    }
+
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(info));
+  };
+
+  const getSavedToastInfo = (): Props | null => {
+    const data = window.localStorage.getItem(LOCAL_STORAGE_KEY);
+    return data != null ? JSON.parse(data) : null;
+  };
+
+  const clearSavedToast = () => {
+    window.localStorage.removeItem(LOCAL_STORAGE_KEY);
+  };
+
+  return { saveToastInfo, getSavedToastInfo, clearSavedToast };
+};

--- a/src/common/hooks/useToast.ts
+++ b/src/common/hooks/useToast.ts
@@ -4,12 +4,6 @@ import { ToastProps } from '../components/Toast';
 
 const LOCAL_STORAGE_KEY = '@depromeet/toast-key';
 
-// interface Props extends ComponentProps<typeof Toast> {
-//   type: ToastType;
-//   time?: number;
-//   showOnNextPage?: boolean;
-// }
-
 export const useToast = () => {
   const saveToastInfo = (info: ToastProps) => {
     const prevData = window.localStorage.getItem(LOCAL_STORAGE_KEY);

--- a/src/common/hooks/useToast.ts
+++ b/src/common/hooks/useToast.ts
@@ -1,17 +1,17 @@
-import { ComponentProps } from 'react';
+// import { ComponentProps } from 'react';
 
-import { Toast, ToastType } from '../components/Toast';
+import { ToastProps } from '../components/Toast';
 
 const LOCAL_STORAGE_KEY = '@depromeet/toast-key';
 
-interface Props extends ComponentProps<typeof Toast> {
-  type: ToastType;
-  time?: number;
-  showOnNextPage?: boolean;
-}
+// interface Props extends ComponentProps<typeof Toast> {
+//   type: ToastType;
+//   time?: number;
+//   showOnNextPage?: boolean;
+// }
 
 export const useToast = () => {
-  const saveToastInfo = (info: Props) => {
+  const saveToastInfo = (info: ToastProps) => {
     const prevData = window.localStorage.getItem(LOCAL_STORAGE_KEY);
 
     if (prevData != null) {
@@ -26,7 +26,7 @@ export const useToast = () => {
     window.localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(info));
   };
 
-  const getSavedToastInfo = (): Props | null => {
+  const getSavedToastInfo = (): ToastProps | null => {
     const data = window.localStorage.getItem(LOCAL_STORAGE_KEY);
     return data != null ? JSON.parse(data) : null;
   };


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
- 페이지 이동 후에 보여야하는 toast의 특성을 고려하여 localstorage를 이용해 toast component를 적용했습니다. 
- localstorage에 toast 정보를 저장하고 삭제하는 useToast hook을 구현했습니다. 

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

## 💁 무엇이 어떻게 바뀌나요?

- 디자인 레퍼런스:
<img src='https://github.com/depromeet/toks-web/assets/89721027/3b5b49cd-b15b-48c6-9d85-a4d9235d0980' width=50%/>


## 💬 리뷰어분들께

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->
