### PR TITLE
feat(auth): axios interceptor 이용하여 auth check

### DIFF
--- a/src/app/kakao-auth/page.tsx
+++ b/src/app/kakao-auth/page.tsx
@@ -5,7 +5,7 @@ import { deleteCookie, setCookie } from 'cookies-next';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
-import { getUserInfo } from '@/common';
+import { getFirstUserInfo } from '@/common';
 import { QUERY_KEYS } from '@/common/constants/queryKeys';
 import { useToast } from '@/common/hooks/useToast';
 import { isToksError } from '@/common/utils/http';
@@ -44,7 +44,7 @@ const KakaoAuth = () => {
     QUERY_KEYS.GET_USER_INFO(accessToken),
     async () => {
       try {
-        return await getUserInfo();
+        return await getFirstUserInfo({ accessToken: accessToken as string });
       } catch (err: unknown) {
         if (isToksError(err) && err.status === 404) {
           router.replace('/nickname');

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,32 +1,14 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import { useLayoutEffect } from 'react';
 
-import { Text, Tooltip } from '@/common';
-
-export default function Home() {
+export default function () {
   const router = useRouter();
 
-  return (
-    <div className="relative">
-      <Text
-        typo="headingL"
-        color="success"
-        onClick={() =>
-          router.push('https://api.tokstudy.com/oauth2/authorize/kakao')
-        }
-      >
-        login
-      </Text>
-      <Tooltip
-        message="관심있는 카테고리"
-        isVisibleTooltip={true}
-        isFirstRender={true}
-      >
-        <Text typo="subheading" color="success">
-          Tooltips!!
-        </Text>
-      </Tooltip>
-    </div>
-  );
+  useLayoutEffect(() => {
+    router.replace('/toks-main');
+  }, [router]);
+
+  return null;
 }

--- a/src/app/toks-main/page.tsx
+++ b/src/app/toks-main/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from 'react';
 
 import { FloatingButton, Toast, ToastProps } from '@/common';
-import { useToast } from '@/common/hooks/useToast';
+import { useToast } from '@/common/hooks';
 
 import { CardList } from './components/CardList';
 import { CategoryBottomSheet } from './components/CategoryBottomSheet';

--- a/src/common/hooks/index.ts
+++ b/src/common/hooks/index.ts
@@ -4,3 +4,4 @@ export * from './useAuth';
 export * from './useIntersectionObserver';
 export * from './useThrottle';
 export * from './usePreventedScroll';
+export * from './useToast';

--- a/src/common/remotes/userInfo/index.ts
+++ b/src/common/remotes/userInfo/index.ts
@@ -5,3 +5,17 @@ import { GetUserInfo } from './types';
 export const getUserInfo = async () => {
   return await http.get<GetUserInfo>('/api/v1/auth/my-infos');
 };
+
+export async function getFirstUserInfo({
+  accessToken,
+}: {
+  accessToken: string;
+}): Promise<Response> {
+  return fetch(`${process.env.NEXT_PUBLIC_BASE_URL}api/v1/auth/status`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'X-TOKS-AUTH-TOKEN': accessToken,
+    },
+  });
+}

--- a/src/common/utils/http.ts
+++ b/src/common/utils/http.ts
@@ -1,6 +1,8 @@
 import axios, { AxiosError, AxiosResponse, isAxiosError } from 'axios';
 import type { AxiosInstance, AxiosRequestConfig } from 'axios';
-import { getCookie } from 'cookies-next';
+import { deleteCookie, getCookie, setCookie } from 'cookies-next';
+
+import { getNewToken } from '@/middleware';
 
 import { API_URL } from '../constants';
 
@@ -33,6 +35,42 @@ export interface HttpClient extends AxiosInstance {
 }
 
 export const http: HttpClient = axiosInstance;
+
+export const authToken = {
+  access: (() => {
+    try {
+      return getCookie('accessToken');
+    } catch (err) {
+      return null;
+    }
+  })(),
+  refresh: (() => {
+    try {
+      return getCookie('refreshToken');
+    } catch (err) {
+      return null;
+    }
+  })(),
+  refetch: () => {
+    authToken.access = getCookie('accessToken');
+    authToken.refresh = getCookie('refreshToken');
+    return;
+  },
+  destroy: () => {
+    deleteCookie('accessToken');
+    deleteCookie('refreshToken');
+    authToken.access = null;
+    authToken.refresh = null;
+  },
+};
+
+export const redirectToLoginPage = () => {
+  const isDev = window.location.hostname === 'localhost';
+
+  window.location.href = isDev
+    ? 'http://localhost:3000/toks-main'
+    : 'https://tokstudy.com/toks-main';
+};
 
 // axios error custom to toks error
 export interface ToksErrorResponse {
@@ -89,11 +127,59 @@ http.interceptors.response.use(
     )
 );
 
+const publicAPIStore = new Set();
+
+http.interceptors.response.use(
+  (response) => response.data,
+  async function (error: ToksError) {
+    const requestUrl = error.config?.url ?? error.response?.config.url;
+
+    if (requestUrl != null && publicAPIStore.has(requestUrl)) {
+      publicAPIStore.delete(requestUrl);
+      return null;
+    }
+
+    if (isToksError(error) && error.status === 401) {
+      const refreshToken = getCookie('refreshToken') as string;
+      try {
+        // refresh로 accessToken 받아오는 로직 추가
+        const token = await (
+          await getNewToken({
+            refreshToken,
+          })
+        ).json();
+
+        if (token) {
+          authToken.destroy();
+          setCookie('accessToken', token.data.accessToken);
+          setCookie('refreshToken', refreshToken);
+        }
+      } catch (e: unknown) {
+        // 로그인 페이지로 리다이렉트
+        authToken.destroy();
+        redirectToLoginPage();
+      }
+
+      // redirect가 완료되고, API가 종료될 수 있도록 delay를 추가합니다.
+      await delay(500);
+      return null;
+    } else {
+      throw error;
+    }
+  }
+);
+
 http.interceptors.request.use((config) => {
   const accessToken = getCookie('accessToken');
   if (accessToken) {
-    config.headers['X-TOKS-AUTH-TOKEN'] = `${accessToken}`;
+    config.headers['X-TOKS-AUTH-TOKEN'] = accessToken;
+    http.defaults.headers.common['X-TOKS-AUTH-TOKEN'] = accessToken;
   }
+
   return config;
 });
 http.interceptors.response.use((response) => response.data.data);
+
+function delay(time: number) {
+  return new Promise((res) => setTimeout(res, time));
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -98,5 +98,5 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/nickname', '/quiz/:path*', '/my-page'],
+  matcher: ['/nickname', '/quiz/:path*', '/my-page', '/toks-main'],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -25,7 +25,7 @@ async function getAuthStatus({
   });
 }
 
-async function getNewToken({
+export async function getNewToken({
   refreshToken,
 }: {
   refreshToken: string;

--- a/src/queries/useQuizListInfinityQuery/index.ts
+++ b/src/queries/useQuizListInfinityQuery/index.ts
@@ -34,7 +34,7 @@ export const useQuizListInfinityQuery = () => {
         size: 15,
       });
     },
-    getNextPageParam: ({ page, totalPage }) => {
+    getNextPageParam: ({ page = 0, totalPage }) => {
       if (page >= totalPage) {
         return undefined;
       }


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
- axios 사용시 토큰 만료가 체킹되지 않는 이슈를 해결했습니다. 
- 미들웨어 같은 경우 페이지 라우팅 되기 전에 middleware가 자동으로 실행된다고 알고 있어 한 페이지 내부에서 axios로 여러번 요청하는 경우는 auth checking이 되지 않아 interceptor 로직을 추가해뒀습니다. 

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

## 💬 리뷰어분들께
- auth 로직이 너무 파편화되어 있어서 이부분은 배포 이후에 리팩토링 할게요 흐흑 
- auth 체크 같은 경우 편리하게 작업하기 위해 authToken을 만들었는데 이상하게 인터셉터 내부에서 사용할 때 동작이 잘 안되더라구요..? 그래서 내부에서 만들어 놓고 사용하지 못하는 이슈가.. 이것도 배포 후에 다시 한번 살펴볼게요 ! 
<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->
