### PR TITLE
fix(qa): next Metadata 이용하여 viewport 적용

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,12 +2,18 @@ import './globals.css';
 import clsx from 'clsx';
 import type { Metadata } from 'next';
 import localFont from 'next/font/local';
+import Head from 'next/head';
 
 import { bgColor } from '@/common/foundation';
 import QueryProvider from '@/common/providers/QueryProvider';
 import * as gtag from '@/common/utils';
 
 export const metadata: Metadata = {
+  viewport: {
+    width: 'device-width',
+    initialScale: 1,
+    maximumScale: 1,
+  },
   openGraph: {
     title: '똑스 : 지식을 키우는 첫 시작!',
     description: '똑스와 함께, 퀴즈로 똑똑해지고 더 나은 습관 만들기',
@@ -25,11 +31,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <head>
-        <meta
-          name="viewport"
-          content="initial-scale=1.0,user-scalable=no,maximum-scale=1,width=device-width, height=device-height"
-        />
+      <Head>
         <link
           rel="icon"
           href="https://toks-web-assets.s3.amazonaws.com/legacy/toktok.ico"
@@ -68,7 +70,7 @@ export default function RootLayout({
 `,
           }}
         />
-      </head>
+      </Head>
       <body className={clsx(pretendard.className, bgColor['gray120'])}>
         <QueryProvider>
           <StyledLayout>{children}</StyledLayout>


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
- close #353 
- meta tag 내부에 적용되어 있던 viewport 설정을 next Metadata를 이용하도록 수정했습니다. 
<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

## 💁 무엇이 어떻게 바뀌나요?

- 관련 슬랙 링크: https://5gaeanmal.slack.com/archives/C04HVDY7LFJ/p1699096075185229

## 💬 리뷰어분들께

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->
