### PR TITLE
feat(qa): 변경된 OX퀴즈 결과 화면 반영, 추천 퀴즈 카드 세줄 초과시 말줄임 구현

### DIFF
--- a/src/app/quiz/[quizId]/@detail/page.tsx
+++ b/src/app/quiz/[quizId]/@detail/page.tsx
@@ -7,7 +7,7 @@ import {
   useGetQuizDetailQuery,
   useSubmitQuizMutation,
 } from '@/app/quiz/hooks/';
-import { QuizButtonType } from '@/app/quiz/models/quiz';
+import { OX, QuizButtonType } from '@/app/quiz/models/quiz';
 import { Text, bgColor } from '@/common';
 
 import { Comments } from '../../components/Comment/Comments';
@@ -101,20 +101,19 @@ function DetailPage({ params: { quizId } }: Props) {
               </>
             ) : isSubmitted ? (
               <div className="mx-auto flex flex-col items-center">
-                <Thumbnail OXType={isOXCorrectAnswer ? 'O' : 'X'} />
+                <Thumbnail OXType={oxAnswer as OX} />
                 <Text className="mt-20px " typo="headingL" color="gray10">
                   {isOXCorrectAnswer
-                    ? '딩동댕! 정답이에요.'
-                    : '앗, 오답이에요! 정답은...'}
+                    ? `딩동댕! 정답은 ${oxAnswer}에요.`
+                    : `앗, 정답은 ${oxAnswer}에요.`}
                 </Text>
-                <Text
-                  className="mt-2px "
-                  typo="bodyBold"
-                  color={isOXCorrectAnswer ? 'blue10' : 'dangerDefault'}
-                >
-                  {checkSelectedAnswer('O')
-                    ? answerParticipationLabel.left
-                    : answerParticipationLabel.right}
+                <Text className="mt-2px " typo="bodyBold" color="gray60">
+                  {clsx(
+                    '정답률',
+                    oxAnswer === 'O'
+                      ? answerParticipationLabel.left
+                      : answerParticipationLabel.right
+                  )}
                 </Text>
                 <Text className="mt-24px block" typo="body" color="white">
                   {oxDescription}

--- a/src/common/components/QuizCard/index.tsx
+++ b/src/common/components/QuizCard/index.tsx
@@ -92,13 +92,15 @@ export const QuizCard = ({
         >
           {categoryTitle}
         </Text>
-        <Text
-          className="inline-flex flex-1 -translate-y-0.5 items-center pt-12px"
-          typo={isSmall ? 'subheadingBold' : 'headingM'}
-          color="gray10"
-        >
-          {quizDescription}
-        </Text>
+        <div className="inline-flex flex-1 -translate-y-0.5 items-center pt-12px">
+          <Text
+            className={clsx({ 'line-clamp-3': isSmall })}
+            typo={isSmall ? 'subheadingBold' : 'headingM'}
+            color="gray10"
+          >
+            {quizDescription}
+          </Text>
+        </div>
         <div className="flex gap-8px">
           <Text typo="caption" color="gray50">
             🔥 참여 {likeCount}명

--- a/src/common/components/Text/index.tsx
+++ b/src/common/components/Text/index.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { HTMLAttributes, ReactNode, createElement } from 'react';
 
 import { KeyOfColor, KeyOfTypography, textColor, typography } from '@/common';
@@ -22,7 +23,7 @@ export function Text({
   return createElement(
     as,
     {
-      className: `${textColor[color]} ${typography[typo]} ${className}`,
+      className: clsx(textColor[color], typography[typo], className),
       ...rest,
     },
     [children]


### PR DESCRIPTION
fix #357 
## 💡 왜 PR을 올렸나요?
- QA로 나온 퀴즈 상세 화면 > 추천 퀴즈 카드의 description이 세줄을 초과할때 말줄임을 구현했습니다
- 변경된 OX퀴즈의 결과 화면을 반영하였습니다.

## 💁 무엇이 어떻게 바뀌나요?
![스크린샷 2023-11-19 오후 11 48 06](https://github.com/depromeet/toks-web/assets/47452547/e11c0be8-ddbc-42e4-8b81-93a4ad672dee)
![스크린샷 2023-11-19 오후 11 47 57](https://github.com/depromeet/toks-web/assets/47452547/c02619a4-d629-4bd2-8ca5-34eaf0a1101e)

- 관련 슬랙 링크:
[말줄임 구현 QA](https://5gaeanmal.slack.com/archives/C04HVDY7LFJ/p1699095424406149)
[OX퀴즈 결과화면 변경](https://5gaeanmal.slack.com/archives/C044R1B6526/p1699794186129589)

## 💬 리뷰어분들께
PR너무 오랜만에 올리네요 ㅎ.,.,.,
두 개의 기능에 변경점이 크지 않아서 굳이 따로 올리지 않고 한꺼번에 올렸습니다

아 그리고 메인화면의 퀴즈 카드에서도 말줄임이 필요하다면 line-clamp-3부분에 추가하면 될 것 같습니다
메인화면도 줄 제한 들어갈거 같은데 몇 줄 제한인지 몰라서... 일단 작은 버전만 해놨어요

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->
