### PR TITLE
feat(qa): 비로그인 유저 구분을 위한 uuid 생성 및 적용

### DIFF
--- a/src/common/utils/http.ts
+++ b/src/common/utils/http.ts
@@ -39,6 +39,7 @@ export const http: HttpClient = axiosInstance;
 
 // uuid
 export const uuid = {
+  FIELD_NAME: 'TOKS-USER-KEY',
   uuid: (() => {
     try {
       return localStorage.getItem('uuid');
@@ -200,8 +201,8 @@ http.interceptors.request.use((config) => {
     config.headers['X-TOKS-AUTH-TOKEN'] = accessToken;
     http.defaults.headers.common['X-TOKS-AUTH-TOKEN'] = accessToken;
     uuid.destroy();
-    config.headers['TOKS-USER-KEY'] = '';
-    http.defaults.headers.common['TOKS-USER-KEY'] = '';
+    config.headers[uuid.FIELD_NAME] = '';
+    http.defaults.headers.common[uuid.FIELD_NAME] = '';
   } else {
     let toksUserKey = uuid.uuid;
     if (toksUserKey == null) {
@@ -209,13 +210,13 @@ http.interceptors.request.use((config) => {
       toksUserKey = uuid.uuid;
     }
     if (toksUserKey) {
-      config.headers['TOKS-USER-KEY'] = toksUserKey;
-      http.defaults.headers.common['TOKS-USER-KEY'] = toksUserKey;
+      config.headers[uuid.FIELD_NAME] = toksUserKey;
+      http.defaults.headers.common[uuid.FIELD_NAME] = toksUserKey;
     } else {
       const newToksUserKey = uuidv4();
       localStorage.setItem('uuid', newToksUserKey);
-      config.headers['TOKS-USER-KEY'] = newToksUserKey;
-      http.defaults.headers.common['TOKS-USER-KEY'] = newToksUserKey;
+      config.headers[uuid.FIELD_NAME] = newToksUserKey;
+      http.defaults.headers.common[uuid.FIELD_NAME] = newToksUserKey;
     }
   }
   return config;

--- a/src/common/utils/index.ts
+++ b/src/common/utils/index.ts
@@ -1,3 +1,4 @@
 export * from './cn';
 export * from './http';
 export * from './gtag';
+export * from './uuid';

--- a/src/common/utils/uuid.ts
+++ b/src/common/utils/uuid.ts
@@ -1,0 +1,8 @@
+export const uuidv4 = () => {
+  return '10000000-1000-4000-8000-100000000000'.replace(/[018]/g, (c) =>
+    (
+      Number(c) ^
+      (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (Number(c) / 4)))
+    ).toString(16)
+  );
+};


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
- close #365 
- 비로그인 유저 구분을 위한 uuid를 생성하고 적용했습니다. 
- 비로그인 유저에 대해서만 uuid를 헤더에 추가하고 로그인 유저일 경우 기존 uuid를 삭제하고 헤더에 빈 스트링을 보내는 방식으로 구현했습니다. 

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

## 💁 무엇이 어떻게 바뀌나요?

- 관련 슬랙 링크: https://5gaeanmal.slack.com/archives/C04HVDY7LFJ/p1699095708440409

## 💬 리뷰어분들께

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->
