### PR TITLE
fix(toks-main): 무한스크롤 안되는 이슈 fix

### DIFF
--- a/src/app/toks-main/components/CardList.tsx
+++ b/src/app/toks-main/components/CardList.tsx
@@ -45,7 +45,7 @@ export const CardList = () => {
           {...quiz}
         />
       ))}
-      {hasNextPage && <div ref={observeBox} />}
+      <div ref={observeBox} />
     </div>
   );
 };

--- a/src/queries/useQuizListInfinityQuery/index.ts
+++ b/src/queries/useQuizListInfinityQuery/index.ts
@@ -35,7 +35,7 @@ export const useQuizListInfinityQuery = () => {
       });
     },
     getNextPageParam: ({ page = 0, totalPage }) => {
-      if (page >= totalPage) {
+      if (page >= totalPage - 1) {
         return undefined;
       }
       return page + 1;


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?

- ref가 갱신되지 않아서 생긴 이슈였네요.. 테스트할때는 리렌더해서 됐었고 첫 로딩시만 안되어서 다시 작업했습니다.
- 돔 렌더될 때 전부 렌더되도록 수정했습니다. CALLBACK REF 써도 똑같네요