### PR TITLE
feat(qa): OX퀴즈 버튼 이름 서버 데이터 반영, 비로그인 유저에 대해 좋아요 버튼 클릭 제어

### DIFF
--- a/src/app/quiz/[quizId]/@detail/page.tsx
+++ b/src/app/quiz/[quizId]/@detail/page.tsx
@@ -124,13 +124,13 @@ function DetailPage({ params: { quizId } }: Props) {
                 <QuizButton
                   isSubmitted={isSubmitted}
                   OXType={isExistOXImage ? undefined : 'O'}
-                  name="예"
+                  name={buttonLeft.button.name}
                   onClick={() => submitQuiz('O')}
                 />
                 <QuizButton
                   isSubmitted={isSubmitted}
                   OXType={isExistOXImage ? undefined : 'X'}
-                  name="아니오"
+                  name={buttonRight.button.name}
                   onClick={() => submitQuiz('X')}
                 />
               </>

--- a/src/app/quiz/components/Comment/LikeButton.tsx
+++ b/src/app/quiz/components/Comment/LikeButton.tsx
@@ -2,11 +2,13 @@
 
 import clsx from 'clsx';
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 import { HTMLAttributes } from 'react';
 
 import { useLikeCommentMutation } from '@/app/quiz/hooks/useLikeCommentMutation';
 import { useUnlikeCommentMutation } from '@/app/quiz/hooks/useUnlikeCommentMutation';
-import { Text } from '@/common';
+import { Text, useAuth } from '@/common';
+import { LOGIN_URL } from '@/common/constants';
 
 import like_off from '../../../../../public/img/icon/like_off.svg';
 import like_on from '../../../../../public/img/icon/like_on.svg';
@@ -28,15 +30,20 @@ function LikeButton({
   className,
   ...rest
 }: LikeButtonProps) {
-  // Mutation을 통해서 좋아요, 좋아요 취소를 하게 되면 퀴즈 데이터 전체가 업데이트 되게 했는데
-  // 렌더링 효율이 떨어지는 것 같다면 데이터 업데이트가 아니라 useState로 숫자를 업데이트 하고 아이콘을 변경하는 방식으로 수정해야 함.
+  const { isLogin } = useAuth();
+  const router = useRouter();
   const { likeComment } = useLikeCommentMutation(String(commentId), quizId);
   const { unlikeComment } = useUnlikeCommentMutation(String(commentId), quizId);
   return (
     <button
       className={clsx(className, 'flex items-center gap-x-4px')}
       {...rest}
-      onClick={() => (isLiked ? unlikeComment : likeComment)()}
+      onClick={() => {
+        if (isLogin) {
+          return (isLiked ? unlikeComment : likeComment)();
+        }
+        router.replace(LOGIN_URL);
+      }}
     >
       <Image
         src={isLiked ? like_on : like_off}


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
- OX퀴즈의 버튼 이름이 "예", "아니오"로 고정되어있었는데 서버에서 받아오는 값이 들어가게 변경했습니다
- 비로그인 유저가 좋아요 버튼을 클릭할 경우 로그인 페이지로 이동하게 했습니다