### PR TITLE
feat(nickname): 초기 로그인 유저 닉네임 세팅 로직 수정

### DIFF
--- a/src/app/nickname/hooks/useCreateNicknameForm.ts
+++ b/src/app/nickname/hooks/useCreateNicknameForm.ts
@@ -15,8 +15,8 @@ export interface CheckNicknameFormValues {
 
 type NicknameFormType = {
   pathName: string;
-  accessToken: string;
-  refreshToken: string;
+  accessToken?: string;
+  refreshToken?: string;
 };
 
 export const useCreateNicknameForm = ({

--- a/src/app/nickname/hooks/useCreateNicknameForm.ts
+++ b/src/app/nickname/hooks/useCreateNicknameForm.ts
@@ -1,4 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
+import { deleteCookie, setCookie } from 'cookies-next';
 import { useRouter } from 'next/navigation';
 import { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
@@ -12,7 +13,17 @@ export interface CheckNicknameFormValues {
   nickname: string;
 }
 
-export const useCreateNicknameForm = (pathName: string) => {
+type NicknameFormType = {
+  pathName: string;
+  accessToken: string;
+  refreshToken: string;
+};
+
+export const useCreateNicknameForm = ({
+  pathName,
+  accessToken,
+  refreshToken,
+}: NicknameFormType) => {
   const {
     register,
     getValues,
@@ -49,6 +60,9 @@ export const useCreateNicknameForm = (pathName: string) => {
 
   const { mutate: nicknameMutation } = useMutation(async () => {
     const nickname = getValues('nickname');
+    // 먼저 쿠키 세팅을 해줘야 nickname patch 가능
+    setCookie('accessToken', accessToken);
+    setCookie('refreshToken', refreshToken);
     try {
       const res = await patchNickname(nickname);
       if (res !== null) {
@@ -60,6 +74,7 @@ export const useCreateNicknameForm = (pathName: string) => {
           type: 'success',
           title: '닉네임 설정을 완료하였어요.',
         });
+
         pathName === '/nickname/update'
           ? router.replace('/my-page')
           : router.replace('/toks-main');
@@ -68,6 +83,9 @@ export const useCreateNicknameForm = (pathName: string) => {
       if (isToksError(err) && err.errorCode === 'DUPLICATED_NICKNAME') {
         setError('nickname', { message: '이미 존재하는 닉네임입니다.' });
       }
+      // 에러 발생시 토큰 삭제
+      deleteCookie('accessToken');
+      deleteCookie('refreshToken');
     }
   });
 

--- a/src/app/nickname/hooks/useCreateNicknameForm.ts
+++ b/src/app/nickname/hooks/useCreateNicknameForm.ts
@@ -61,8 +61,11 @@ export const useCreateNicknameForm = ({
   const { mutate: nicknameMutation } = useMutation(async () => {
     const nickname = getValues('nickname');
     // 먼저 쿠키 세팅을 해줘야 nickname patch 가능
-    setCookie('accessToken', accessToken);
-    setCookie('refreshToken', refreshToken);
+    if (accessToken && refreshToken) {
+      setCookie('accessToken', accessToken);
+      setCookie('refreshToken', refreshToken);
+    }
+
     try {
       const res = await patchNickname(nickname);
       if (res !== null) {

--- a/src/app/nickname/page.tsx
+++ b/src/app/nickname/page.tsx
@@ -33,7 +33,7 @@ const Nickname = () => {
   const [toastData, setToastData] = useState<ToastProps | null>(null);
 
   useEffect(() => {
-    // 닉네임 설정 안하고 이탈한 경우 대비해 토큰 삭제
+    // 닉네임 설정을 마치지 않고 이탈한 경우 대비해 토큰 삭제
     deleteCookie('accessToken');
     deleteCookie('refreshToken');
     setToastData(getSavedToastInfo());

--- a/src/app/nickname/page.tsx
+++ b/src/app/nickname/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { deleteCookie, getCookie } from 'cookies-next';
 import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
@@ -12,6 +13,10 @@ import { useCreateNicknameForm } from './hooks/useCreateNicknameForm';
 
 const Nickname = () => {
   const pathName = usePathname();
+
+  const [accessToken] = useState<string>(getCookie('accessToken') as string);
+  const [refreshToken] = useState<string>(getCookie('refreshToken') as string);
+
   const {
     register,
     errors,
@@ -21,13 +26,16 @@ const Nickname = () => {
     isRequiredText,
     hasExclamationMark,
     nicknameMutation,
-  } = useCreateNicknameForm(pathName);
+  } = useCreateNicknameForm({ pathName, accessToken, refreshToken });
   const divRef = useWindowResize();
 
   const { getSavedToastInfo, clearSavedToast } = useToast();
   const [toastData, setToastData] = useState<ToastProps | null>(null);
 
   useEffect(() => {
+    // 닉네임 설정 안하고 이탈한 경우 대비해 토큰 삭제
+    deleteCookie('accessToken');
+    deleteCookie('refreshToken');
     setToastData(getSavedToastInfo());
     clearSavedToast();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -45,7 +53,8 @@ const Nickname = () => {
       )}
       <form
         onSubmit={(e) => {
-          e.preventDefault(), nicknameMutation();
+          e.preventDefault();
+          nicknameMutation();
         }}
       >
         <NicknameBox

--- a/src/app/nickname/update/page.tsx
+++ b/src/app/nickname/update/page.tsx
@@ -32,7 +32,7 @@ const UpdateNickname = () => {
     isRequiredText,
     hasExclamationMark,
     nicknameMutation,
-  } = useCreateNicknameForm(pathName);
+  } = useCreateNicknameForm({ pathName });
   const divRef = useWindowResize();
 
   return (

--- a/src/app/template.tsx
+++ b/src/app/template.tsx
@@ -15,9 +15,18 @@ export default function Template({ children }: StrictPropsWithChildren) {
   return (
     <RecoilRoot>
       <GlobalPortal.Provider>
-        {pathName === '/toks-main' ? <Appbar /> : <BackHeader />}
-        {children}
-        <CategoryBottomSheet />
+        {pathName === '/toks-main' ? (
+          <>
+            <Appbar />
+            {children}
+            <CategoryBottomSheet />
+          </>
+        ) : (
+          <>
+            <BackHeader />
+            {children}
+          </>
+        )}
       </GlobalPortal.Provider>
     </RecoilRoot>
   );

--- a/src/common/remotes/userInfo/index.ts
+++ b/src/common/remotes/userInfo/index.ts
@@ -11,7 +11,7 @@ export async function getFirstUserInfo({
 }: {
   accessToken: string;
 }): Promise<Response> {
-  return fetch(`${process.env.NEXT_PUBLIC_BASE_URL}api/v1/auth/status`, {
+  return fetch(`${process.env.NEXT_PUBLIC_BASE_URL}api/v1/auth/my-infos`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json; charset=utf-8',


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
- 초기 로그인 유저의 경우 닉네임 설정 페이지로 리다이렉트 될 수 있도록 수정했습니다. 
- 유저가 닉네임을 설정하던 도중 이탈할 가능성을 염두하여 닉네임 페이지에서는 일단 쿠키에서 토큰을 삭제하고, submit 버튼 클릭시 mutation 전에 쿠키에 토큰을 세팅할 수 있도록 로직을 수정했습니다. 

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

## 💁 무엇이 어떻게 바뀌나요?

- 관련 슬랙 링크: https://5gaeanmal.slack.com/archives/C04HVDY7LFJ/p1701415392516879

## 💬 리뷰어분들께
- fetch를 사용할 때는 try catch가 아니라 ok로 에러 잡기 .. 요거 때문에 에러 핸들링이 제대로 안되고 있었던 것 같네요 

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->
