### PR TITLE
refactor(http): uuid setting cookie 사용하도록 변경

### DIFF
--- a/src/common/utils/http.ts
+++ b/src/common/utils/http.ts
@@ -42,18 +42,18 @@ export const uuid = {
   FIELD_NAME: 'TOKS-USER-KEY',
   uuid: (() => {
     try {
-      return localStorage.getItem('uuid');
+      return getCookie('uuid');
     } catch (err) {
       return null;
     }
   })(),
   refetch: () => {
-    uuid.uuid = localStorage.getItem('uuid');
+    uuid.uuid = getCookie('uuid');
     return;
   },
   destroy: () => {
     try {
-      localStorage.removeItem('uuid');
+      deleteCookie('uuid');
       uuid.uuid = null;
     } catch (err) {
       console.log(err);
@@ -214,7 +214,8 @@ http.interceptors.request.use((config) => {
       http.defaults.headers.common[uuid.FIELD_NAME] = toksUserKey;
     } else {
       const newToksUserKey = uuidv4();
-      localStorage.setItem('uuid', newToksUserKey);
+      setCookie('uuid', newToksUserKey);
+      console.log(newToksUserKey);
       config.headers[uuid.FIELD_NAME] = newToksUserKey;
       http.defaults.headers.common[uuid.FIELD_NAME] = newToksUserKey;
     }


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
- 서버컴포넌트 대응을 위해 uuid 저장소를 localStorage에서 cookie를 사용하도록 변경했습니다. 

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

## 💁 무엇이 어떻게 바뀌나요?

## 💬 리뷰어분들께

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->
