### PR TITLE
refactor(my-page): my-page suspense 적용 및 root page server component로 변경

### DIFF
--- a/src/app/(AppBarHeader)/layout.tsx
+++ b/src/app/(AppBarHeader)/layout.tsx
@@ -6,7 +6,8 @@ export default function AppBarLayout({ children }: StrictPropsWithChildren) {
     <>
       <Appbar />
       {children}
-      <CategoryBottomSheet />
+      {/* TODO: 에러 고치기 .. */}
+      {/* <CategoryBottomSheet /> */}
     </>
   );
 }

--- a/src/app/(AppBarHeader)/layout.tsx
+++ b/src/app/(AppBarHeader)/layout.tsx
@@ -1,5 +1,4 @@
 import { Appbar } from './_components/Appbar';
-import { CategoryBottomSheet } from './toks-main/_components/CategoryBottomSheet';
 
 export default function AppBarLayout({ children }: StrictPropsWithChildren) {
   return (

--- a/src/app/(BackHeader)/my-page/@toast/page.tsx
+++ b/src/app/(BackHeader)/my-page/@toast/page.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+import { useToast } from '@/common';
+import { Toast as ToastComponent, ToastProps } from '@/common/components/Toast';
+
+const Toast = () => {
+  const { getSavedToastInfo, clearSavedToast } = useToast();
+  const [toastData, setToastData] = useState<ToastProps | null>(null);
+
+  useEffect(() => {
+    console.log('hi');
+    setToastData(getSavedToastInfo());
+    console.log(getSavedToastInfo());
+    console.log(toastData);
+
+    clearSavedToast();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (toastData === null) {
+    return null;
+  }
+
+  return (
+    <ToastComponent
+      isShow={toastData.isShow}
+      type={toastData.type}
+      direction={toastData.direction}
+      title={toastData.title}
+    />
+  );
+};
+
+export default Toast;

--- a/src/app/(BackHeader)/my-page/@toast/page.tsx
+++ b/src/app/(BackHeader)/my-page/@toast/page.tsx
@@ -11,8 +11,6 @@ const Toast = () => {
 
   useEffect(() => {
     setToastData(getSavedToastInfo());
-    console.log(getSavedToastInfo());
-    console.log(toastData);
 
     clearSavedToast();
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/app/(BackHeader)/my-page/@toast/page.tsx
+++ b/src/app/(BackHeader)/my-page/@toast/page.tsx
@@ -10,7 +10,6 @@ const Toast = () => {
   const [toastData, setToastData] = useState<ToastProps | null>(null);
 
   useEffect(() => {
-    console.log('hi');
     setToastData(getSavedToastInfo());
     console.log(getSavedToastInfo());
     console.log(toastData);

--- a/src/app/(BackHeader)/my-page/@userInfo/page.tsx
+++ b/src/app/(BackHeader)/my-page/@userInfo/page.tsx
@@ -18,11 +18,7 @@ const UserInfo = () => {
     <div className="w-full flex-col items-center pt-20px text-center">
       <div className="mx-auto mb-24px h-96px w-96px overflow-hidden rounded-full">
         <Image
-          src={
-            user.profileImageUrl
-              ? user.profileImageUrl
-              : ICON_URL.EMOJI_BASE_GRAY
-          }
+          src={user ? user.profileImageUrl : ICON_URL.EMOJI_BASE_GRAY}
           alt="프로필 이미지"
           width={96}
           height={96}

--- a/src/app/(BackHeader)/my-page/@userInfo/page.tsx
+++ b/src/app/(BackHeader)/my-page/@userInfo/page.tsx
@@ -1,28 +1,32 @@
 'use client';
 
+import { getCookie } from 'cookies-next';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
 
-import { ICON_URL, IMAGE_URL } from '@/common';
+import { ICON_URL } from '@/common';
 import { Text } from '@/common/components/Text';
-import { useAuth } from '@/common/hooks';
+
+import { useSuspenseUserInfoQuery } from '../_lib/hooks/useSuspenseUserInfoQuery';
 
 const UserInfo = () => {
-  const { user } = useAuth();
-  const [profileImage, setProfileImage] = useState(ICON_URL.EMOJI_BASE_GRAY);
   const router = useRouter();
-
-  useEffect(() => {
-    if (user && user.profileImageUrl !== IMAGE_URL.BASE_KAKAO) {
-      setProfileImage(user.profileImageUrl);
-    }
-  }, [user]);
+  const accessToken = getCookie('accessToken');
+  const { data: user } = useSuspenseUserInfoQuery(accessToken as string);
 
   return (
     <div className="w-full flex-col items-center pt-20px text-center">
       <div className="mx-auto mb-24px h-96px w-96px overflow-hidden rounded-full">
-        <Image src={profileImage} alt="프로필 이미지" width={96} height={96} />
+        <Image
+          src={
+            user.profileImageUrl
+              ? user.profileImageUrl
+              : ICON_URL.EMOJI_BASE_GRAY
+          }
+          alt="프로필 이미지"
+          width={96}
+          height={96}
+        />
       </div>
       <div className="mb-8px flex h-24px w-full justify-center">
         <Text typo="headingL" color="gray10">

--- a/src/app/(BackHeader)/my-page/@userInfo/page.tsx
+++ b/src/app/(BackHeader)/my-page/@userInfo/page.tsx
@@ -7,18 +7,22 @@ import { useRouter } from 'next/navigation';
 import { ICON_URL } from '@/common';
 import { Text } from '@/common/components/Text';
 
+import { SkeletonUserInfo } from '../_components/SkeletonUserInfo.tsx';
 import { useSuspenseUserInfoQuery } from '../_lib/hooks/useSuspenseUserInfoQuery';
 
 const UserInfo = () => {
   const router = useRouter();
   const accessToken = getCookie('accessToken');
-  const { data: user } = useSuspenseUserInfoQuery(accessToken as string);
+  const { data: userInfo } = useSuspenseUserInfoQuery(accessToken as string);
 
+  if (!userInfo) {
+    return <SkeletonUserInfo />;
+  }
   return (
     <div className="w-full flex-col items-center pt-20px text-center">
       <div className="mx-auto mb-24px h-96px w-96px overflow-hidden rounded-full">
         <Image
-          src={user ? user.profileImageUrl : ICON_URL.EMOJI_BASE_GRAY}
+          src={userInfo ? userInfo.profileImageUrl : ICON_URL.EMOJI_BASE_GRAY}
           alt="프로필 이미지"
           width={96}
           height={96}
@@ -26,7 +30,7 @@ const UserInfo = () => {
       </div>
       <div className="mb-8px flex h-24px w-full justify-center">
         <Text typo="headingL" color="gray10">
-          {user?.nickname}
+          {userInfo?.nickname}
         </Text>
         <Image
           className="ml-4px"
@@ -39,7 +43,7 @@ const UserInfo = () => {
       </div>
       <div className="h-24px">
         <Text typo="body" color="gray40">
-          {user?.email}
+          {userInfo?.email}
         </Text>
       </div>
     </div>

--- a/src/app/(BackHeader)/my-page/@userInfo/page.tsx
+++ b/src/app/(BackHeader)/my-page/@userInfo/page.tsx
@@ -8,7 +8,7 @@ import { ICON_URL, IMAGE_URL } from '@/common';
 import { Text } from '@/common/components/Text';
 import { useAuth } from '@/common/hooks';
 
-export const UserInfo = () => {
+const UserInfo = () => {
   const { user } = useAuth();
   const [profileImage, setProfileImage] = useState(ICON_URL.EMOJI_BASE_GRAY);
   const router = useRouter();
@@ -43,3 +43,5 @@ export const UserInfo = () => {
     </div>
   );
 };
+
+export default UserInfo;

--- a/src/app/(BackHeader)/my-page/@userInfo/page.tsx
+++ b/src/app/(BackHeader)/my-page/@userInfo/page.tsx
@@ -24,7 +24,7 @@ const UserInfo = () => {
       <div className="mx-auto mb-24px h-96px w-96px overflow-hidden rounded-full">
         <Image src={profileImage} alt="프로필 이미지" width={96} height={96} />
       </div>
-      <div className="mb-8px flex w-full justify-center">
+      <div className="mb-8px flex h-24px w-full justify-center">
         <Text typo="headingL" color="gray10">
           {user?.nickname}
         </Text>
@@ -37,9 +37,11 @@ const UserInfo = () => {
           onClick={() => router.push('/nickname/update')}
         />
       </div>
-      <Text typo="body" color="gray40">
-        {user?.email}
-      </Text>
+      <div className="h-24px">
+        <Text typo="body" color="gray40">
+          {user?.email}
+        </Text>
+      </div>
     </div>
   );
 };

--- a/src/app/(BackHeader)/my-page/_components/GoogleFormButton/index.tsx
+++ b/src/app/(BackHeader)/my-page/_components/GoogleFormButton/index.tsx
@@ -1,0 +1,23 @@
+'use client';
+import { useRouter } from 'next/navigation';
+
+import { GOOGLE_FORM_URL } from '@/common';
+import { Button } from '@/common/components/Button';
+
+export const GoogleFormButton = () => {
+  const router = useRouter();
+
+  return (
+    <Button
+      className="w-full"
+      size="L"
+      typo="subheadingBold"
+      backgroundColor="primaryDefault"
+      onClick={() => {
+        router.push(GOOGLE_FORM_URL);
+      }}
+    >
+      이런 퀴즈가 있었으면 좋겠어요
+    </Button>
+  );
+};

--- a/src/app/(BackHeader)/my-page/_components/SkeletonUserInfo.tsx/index.tsx
+++ b/src/app/(BackHeader)/my-page/_components/SkeletonUserInfo.tsx/index.tsx
@@ -1,0 +1,23 @@
+import Image from 'next/image';
+
+import { ICON_URL } from '@/common';
+import { Skeleton } from '@/common/components/Skeleton';
+
+export const SkeletonUserInfo = () => {
+  return (
+    <div className="flex w-full animate-pulse flex-col items-center pt-20px text-center">
+      <div className="mx-auto mb-24px h-96px w-96px overflow-hidden rounded-full">
+        <Image
+          src={ICON_URL.EMOJI_BASE_GRAY}
+          alt="프로필 이미지"
+          width={96}
+          height={96}
+        />
+      </div>
+      <div className="flex w-full flex-col items-center">
+        <Skeleton className="mb-[8px] h-[24px] w-[120px]" />
+        <Skeleton className="m-[4px] h-[16px] w-[200px]" />
+      </div>
+    </div>
+  );
+};

--- a/src/app/(BackHeader)/my-page/_lib/hooks/useSuspenseUserInfoQuery.ts
+++ b/src/app/(BackHeader)/my-page/_lib/hooks/useSuspenseUserInfoQuery.ts
@@ -1,0 +1,10 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { getUserInfo } from '@/common';
+
+export const useSuspenseUserInfoQuery = (accessToken?: string) => {
+  return useSuspenseQuery({
+    queryKey: ['userInfo', accessToken],
+    queryFn: getUserInfo,
+  });
+};

--- a/src/app/(BackHeader)/my-page/layout.tsx
+++ b/src/app/(BackHeader)/my-page/layout.tsx
@@ -2,14 +2,17 @@ import React, { PropsWithChildren } from 'react';
 
 type Props = {
   toast: React.ReactNode;
+  userInfo: React.ReactNode;
 };
 
 export default function MyPageLayout({
   children,
   toast,
+  userInfo,
 }: PropsWithChildren<Props>) {
   return (
     <>
+      {userInfo}
       {children}
       {toast}
     </>

--- a/src/app/(BackHeader)/my-page/layout.tsx
+++ b/src/app/(BackHeader)/my-page/layout.tsx
@@ -1,4 +1,6 @@
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, Suspense } from 'react';
+
+import { SkeletonUserInfo } from './_components/SkeletonUserInfo.tsx';
 
 type Props = {
   toast: React.ReactNode;
@@ -12,7 +14,7 @@ export default function MyPageLayout({
 }: PropsWithChildren<Props>) {
   return (
     <>
-      {userInfo}
+      <Suspense fallback={<SkeletonUserInfo />}>{userInfo}</Suspense>
       {children}
       {toast}
     </>

--- a/src/app/(BackHeader)/my-page/layout.tsx
+++ b/src/app/(BackHeader)/my-page/layout.tsx
@@ -1,0 +1,17 @@
+import React, { PropsWithChildren } from 'react';
+
+type Props = {
+  toast: React.ReactNode;
+};
+
+export default function MyPageLayout({
+  children,
+  toast,
+}: PropsWithChildren<Props>) {
+  return (
+    <>
+      {children}
+      {toast}
+    </>
+  );
+}

--- a/src/app/(BackHeader)/my-page/page.tsx
+++ b/src/app/(BackHeader)/my-page/page.tsx
@@ -1,38 +1,19 @@
 'use client';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
 
 import { GOOGLE_FORM_URL, ICON_URL } from '@/common';
 import { Button } from '@/common/components/Button';
 import { Text } from '@/common/components/Text';
-import { Toast, ToastProps } from '@/common/components/Toast';
-import { useToast } from '@/common/hooks/useToast';
 
 import { LogoutBar } from './_components/LogoutBar';
 import { UserInfo } from './_components/UserInfo';
 
 const MyPage = () => {
-  const [toastData, setToastData] = useState<ToastProps | null>(null);
   const router = useRouter();
-  const { getSavedToastInfo, clearSavedToast } = useToast();
-  useEffect(() => {
-    setToastData(getSavedToastInfo());
-    clearSavedToast();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   return (
     <div className="h-full">
       <div>
-        {toastData && (
-          <Toast
-            isShow={toastData.isShow}
-            type={toastData.type}
-            direction={toastData.direction}
-            title={toastData.title}
-          />
-        )}
         <UserInfo />
         <div className="h-40px" />
         <LogoutBar />

--- a/src/app/(BackHeader)/my-page/page.tsx
+++ b/src/app/(BackHeader)/my-page/page.tsx
@@ -7,14 +7,12 @@ import { Button } from '@/common/components/Button';
 import { Text } from '@/common/components/Text';
 
 import { LogoutBar } from './_components/LogoutBar';
-import { UserInfo } from './_components/UserInfo';
 
 const MyPage = () => {
   const router = useRouter();
   return (
     <div className="h-full">
       <div>
-        <UserInfo />
         <div className="h-40px" />
         <LogoutBar />
         <div className="h-56px" />

--- a/src/app/(BackHeader)/my-page/page.tsx
+++ b/src/app/(BackHeader)/my-page/page.tsx
@@ -1,15 +1,12 @@
-'use client';
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
 
-import { GOOGLE_FORM_URL, ICON_URL } from '@/common';
-import { Button } from '@/common/components/Button';
+import { ICON_URL } from '@/common';
 import { Text } from '@/common/components/Text';
 
+import { GoogleFormButton } from './_components/GoogleFormButton';
 import { LogoutBar } from './_components/LogoutBar';
 
 const MyPage = () => {
-  const router = useRouter();
   return (
     <div className="h-full">
       <div>
@@ -26,17 +23,7 @@ const MyPage = () => {
           height={160}
           alt="로켓 이미지"
         />
-        <Button
-          className="w-full"
-          size="L"
-          typo="subheadingBold"
-          backgroundColor="primaryDefault"
-          onClick={() => {
-            router.push(GOOGLE_FORM_URL);
-          }}
-        >
-          이런 퀴즈가 있었으면 좋겠어요
-        </Button>
+        <GoogleFormButton />
       </div>
     </div>
   );

--- a/src/common/utils/http.ts
+++ b/src/common/utils/http.ts
@@ -92,6 +92,9 @@ export const authToken = {
 
 export const redirectToLoginPage = () => {
   const isDev = process.env.NODE_ENV === 'development';
+  if (typeof window === 'undefined') {
+    return;
+  }
 
   window.location.href = isDev
     ? 'http://localhost:3000/toks-main'


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
- toast와 userInfo에 parallel route를 적용하여 my-page의 root page를 server component로 변경했습니다. 
- react query v5의 useSuspenseQuery를 이용해서 userInfo에 suspense를 적용했습니다. 
- ssr 환경 대응을 위해 util/http 내부에서 window 사용시 window가 undefined인 경우 얼리 리턴 해주었습니다. 

<!-- 예: 이슈대응, 신규피쳐, 리팩토링 ... -->

## 💁 무엇이 어떻게 바뀌나요?

- 디자인 레퍼런스:
![화면 기록 2024-01-19 오후 5 07 50](https://github.com/depromeet/toks-web/assets/89721027/e51e5ed9-7766-48df-bc0c-ebde20013cfe)


## 💬 리뷰어분들께
- 카테고리 bottomsheet 부분 무한 에러 나는 곳 주석처리하고 작업을 해서 아마 ci 통과를 못할 것 같은데 일단 코드 먼저 보시면 좋을 것 같아 Pr 올립니다~~ 리뷰 먼저 남겨주시면 같이 보고 수정해둘게요 !!! 
- 위키도 곧 업로드 해두겠습니다 ㅎ.ㅎ

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->
