### PR TITLE
퀴즈 추천 영역 에러 발생 시 컴포넌트 미노출 반영

### DIFF
--- a/src/app/quiz/[quizId]/@recommendation/error.tsx
+++ b/src/app/quiz/[quizId]/@recommendation/error.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+function Error() {
+  return null;
+}
+
+export default Error;


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
퀴즈 추천 데이터에서 에러 발생시 해당 부분만 노출이 안되게 하기 위해 수정했습니다

## 💬 리뷰어분들께
머지되면 바로 배포할게요!
