### PR TITLE
feat(quiz): CommentPage분리 및 퀴즈 상세 페이지 내 위치 변경, 간격 조정

### DIFF
--- a/src/app/quiz/[quizId]/@comment/page.tsx
+++ b/src/app/quiz/[quizId]/@comment/page.tsx
@@ -29,7 +29,7 @@ function CommentPage({ params: { quizId } }: Props) {
   return (
     <div>
       {isSubmitted && (
-        <div className="mt-32px flex flex-col gap-32px">
+        <div className="mt-48px flex flex-col gap-32px">
           {isLogin && (
             <CommentForm quizId={quizId} commentCount={comments?.length} />
           )}

--- a/src/app/quiz/[quizId]/@comment/page.tsx
+++ b/src/app/quiz/[quizId]/@comment/page.tsx
@@ -1,23 +1,28 @@
+'use client';
+
 import { Comment, CommentForm, GetStartedButton } from '@/app/quiz/components';
+import {
+  useGetCommentListQuery,
+  useGetQuizDetailQuery,
+} from '@/app/quiz/hooks';
 import { useAuth } from '@/common';
 
-import { useGetCommentListQuery } from '../../hooks/useGetCommentListQuery';
-
-type CommentsProps = {
-  quizId: string;
-  isSubmitted: boolean;
+type Props = {
+  params: {
+    quizId: string;
+  };
 };
 
-export const Comments = ({ quizId, isSubmitted }: CommentsProps) => {
-  const {
-    data: comments,
-    // isLoading,
-    // isFetching,
-  } = useGetCommentListQuery(quizId);
+function CommentPage({ params: { quizId } }: Props) {
+  const { data: quizDetail } = useGetQuizDetailQuery(quizId);
+  const { data: comments } = useGetCommentListQuery(quizId);
   const { isLogin } = useAuth();
-  if (!comments) {
+
+  if (comments === undefined || quizDetail === undefined) {
     return null;
   }
+
+  const { isSubmitted } = quizDetail;
 
   const isEmptyComment = comments?.length === 0;
 
@@ -58,4 +63,6 @@ export const Comments = ({ quizId, isSubmitted }: CommentsProps) => {
       )}
     </div>
   );
-};
+}
+
+export default CommentPage;

--- a/src/app/quiz/[quizId]/@detail/page.tsx
+++ b/src/app/quiz/[quizId]/@detail/page.tsx
@@ -14,8 +14,6 @@ import {
 import { OX, QuizButtonType } from '@/app/quiz/models/quiz';
 import { Text, bgColor } from '@/common';
 
-import { Comments } from '../../components/Comment/Comments';
-
 type Props = {
   params: {
     quizId: string;
@@ -142,7 +140,6 @@ function DetailPage({ params: { quizId } }: Props) {
           </div>
         </div>
       </section>
-      <Comments quizId={quizId} isSubmitted={isSubmitted} />
     </div>
   );
 }

--- a/src/app/quiz/[quizId]/@recommendation/page.tsx
+++ b/src/app/quiz/[quizId]/@recommendation/page.tsx
@@ -8,12 +8,12 @@ type Props = {
   };
 };
 
-async function RecommendatonPage({ params: { quizId } }: Props) {
+async function RecommendationPage({ params: { quizId } }: Props) {
   const quizRecommendModels = await getRecommendationByQuizId(quizId);
   const isQuizzesExist = quizRecommendModels.length !== 0;
   return (
     isQuizzesExist && (
-      <div className="mt-64px">
+      <div className="mt-48px">
         <Text className="inline-block" typo="subheadingBold" color="gray10">
           더 많은 퀴즈를 확인해보세요
         </Text>
@@ -26,4 +26,4 @@ async function RecommendatonPage({ params: { quizId } }: Props) {
   );
 }
 
-export default RecommendatonPage;
+export default RecommendationPage;

--- a/src/app/quiz/[quizId]/layout.tsx
+++ b/src/app/quiz/[quizId]/layout.tsx
@@ -7,6 +7,7 @@ import { fetchQuizDetailByQuizID } from '../remotes/quiz';
 type Props = {
   detail: React.ReactNode;
   recommendation: React.ReactNode;
+  comment: React.ReactNode;
   params: { quizId: string };
 };
 
@@ -26,12 +27,13 @@ export async function generateMetadata({
   };
 }
 
-function QuizIdLayout({ detail, recommendation }: Props) {
+function QuizIdLayout({ detail, recommendation, comment }: Props) {
   return (
     <main className="pb-80px">
       <QuizProvider>
         {detail}
         {recommendation}
+        {comment}
         <ScrollToTopButton />
       </QuizProvider>
     </main>

--- a/src/app/quiz/hooks/index.ts
+++ b/src/app/quiz/hooks/index.ts
@@ -1,3 +1,7 @@
 export * from './useCommentListRef';
 export * from './useGetQuizDetailQuery';
+export * from './useGetCommentListQuery';
+export * from './useLikeCommentMutation';
+export * from './useSubmitCommentMutation';
 export * from './useSubmitQuizMutation';
+export * from './useUnlikeCommentMutation';


### PR DESCRIPTION
## 💡 왜 PR을 올렸나요?
- 퀴즈 상세 페이지 내 댓글 영역과 퀴즈 더보기 영역 위치 변경이 요구되어서 작업했습니다.
- 원래 댓글 영역이 상세 페이지 내 있었는데 댓글 영역이 서버 컴포넌트인 더보기 영역 밑에 위치해야 하는 관계로 다시 별도 페이지로 분리 시켰습니다.
- 퀴즈 상세 API를 퀴즈 상세 영역(client), 댓글 영역(client)에서 중복 호출하게 되는데 tanstack-query덕에 두 번째 요청은 캐싱 처리 되네요 ㅎㅎ (처음 해봐서 신기함)

## 💁 무엇이 어떻게 바뀌나요?
<img width="1487" alt="스크린샷 2024-02-18 오후 5 43 11" src="https://github.com/depromeet/toks-web/assets/146903018/37b43f83-c7b5-480e-a2b4-707e69bd0875">

- 디자인 레퍼런스: https://www.figma.com/file/EsxU3h9WzL3dGiojgWU480/Toks-Quiz?type=design&node-id=485%3A717&mode=design&t=IbfIsgHVfyzy7u9S-1
- 관련 슬랙 링크:

## 💬 리뷰어분들께

<!-- # 🆘 긴급 🆘 선 어프루브 후 리뷰를 부탁드립니다 -->

<!--
참고
  - 커밋 타입 종류: feat, fix, perf, refactor, test, ci, docs, build, chore
-->
